### PR TITLE
Add ability to configure a proxy for S3 requests

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -1,15 +1,16 @@
 -record(aws_config, {
-    ec2_host="ec2.amazonaws.com"::string(),
-    s3_host="s3.amazonaws.com"::string(),
-    s3_port=80::non_neg_integer(),
-    s3_prot="https"::string(),
-    sdb_host="sdb.amazonaws.com"::string(),
-    elb_host="elasticloadbalancing.amazonaws.com"::string(),
-    sqs_host="queue.amazonaws.com"::string(),
-    mturk_host="mechanicalturk.amazonaws.com"::string(),
-    mon_host="monitoring.amazonaws.com"::string(),
-    access_key_id::string(),
-    secret_access_key::string()
+          ec2_host="ec2.amazonaws.com"::string(),
+          s3_host="s3.amazonaws.com"::string(),
+          s3_port=80::non_neg_integer(),
+          s3_prot="https"::string(),
+          sdb_host="sdb.amazonaws.com"::string(),
+          elb_host="elasticloadbalancing.amazonaws.com"::string(),
+          sqs_host="queue.amazonaws.com"::string(),
+          mturk_host="mechanicalturk.amazonaws.com"::string(),
+          mon_host="monitoring.amazonaws.com"::string(),
+          access_key_id::string(),
+          secret_access_key::string(),
+          proxy_host="" :: string(),
+          proxy_port=0 :: non_neg_integer()
 }).
 -type(aws_config() :: #aws_config{}).
-


### PR DESCRIPTION
Add proxy host and port fields to the aws_config record.  These settings are checked when setting options for the HTTP request in `erlcloud_s3:s3_request`.
