### PR TITLE
Add httpc options passthru

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -10,7 +10,6 @@
           mon_host="monitoring.amazonaws.com"::string(),
           access_key_id::string(),
           secret_access_key::string(),
-          proxy_host="" :: string(),
-          proxy_port=0 :: non_neg_integer()
+          http_options=[]::proplists:proplist()
 }).
 -type(aws_config() :: #aws_config{}).


### PR DESCRIPTION
- move proxy host and port to http options
- allow other options to httpc to be passed along thru config

(to be used with riak-cs branch `wrd-short-keepalive`)
