### PR TITLE
erlcloud_s3:put_object/6 should not count Content-Type in the request headers

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -630,13 +630,16 @@ put_object(BucketName, Key, Value, Options, HTTPHeaders) ->
 
 -spec put_object(string(), string(), iolist(), proplist(), [{string(), string()}], aws_config()) -> proplist().
 
-put_object(BucketName, Key, Value, Options, HTTPHeaders, Config)
+put_object(BucketName, Key, Value, Options, HTTPHeaders0, Config)
   when is_list(BucketName), is_list(Key), is_list(Value) orelse is_binary(Value),
        is_list(Options) ->
+    {ContentType, HTTPHeaders} = case lists:keytake("Content-Type", 1, HTTPHeaders0) of
+                                     {value, {_, CType}, Rest} -> {CType, Rest};
+                                     false -> {"application/octet-stream", HTTPHeaders0}
+                                 end,
     RequestHeaders = [{"x-amz-acl", encode_acl(proplists:get_value(acl, Options))}|HTTPHeaders]
         ++ [{["x-amz-meta-"|string:to_lower(MKey)], MValue} ||
                {MKey, MValue} <- proplists:get_value(meta, Options, [])],
-    ContentType = proplists:get_value("content-type", HTTPHeaders, "application/octet_stream"),
     ReturnResponse = proplists:get_value(return_response, Options, false),
     POSTData = {iolist_to_binary(Value), ContentType},
     {Headers, Body} = s3_request(Config, put, BucketName, [$/|Key], [], [],


### PR DESCRIPTION
Before this change, if the user supplied a `Content-Type` header for the object, AWS S3 would fail the request signature as below:

> The request signature we calculated does not match the signature you provided. Check your key and signing method.

By removing the option from the `HTTPHeaders` parameter, the request signing succeeds. The internal `s3_request()` function adds the `Content-Type` header back later when submitting the request.