### PR TITLE
R20 compatibility

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,3 @@
 {erl_opts, [debug_info]}.
 
-{deps, [{ibrowse, "4.0.2", {git, "git://github.com/cmullaparthi/ibrowse", {tag, "v4.0.2"}}}]}.
+{deps, [{ibrowse, "4.4.0", {git, "git://github.com/cmullaparthi/ibrowse", {tag, "v4.4.0"}}}]}.

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -19,7 +19,7 @@ aws_request(Method, Host, Path, Params, AccessKeyID, SecretAccessKey) ->
     QueryToSign = erlcloud_http:make_query_string(QParams),
     RequestToSign = [string:to_upper(atom_to_list(Method)), $\n,
                      string:to_lower(Host), $\n, Path, $\n, QueryToSign],
-    Signature = base64:encode(crypto:sha_mac(SecretAccessKey, RequestToSign)),
+    Signature = base64:encode(erlcloud_util:sha_mac(SecretAccessKey, RequestToSign)),
 
     Query = [QueryToSign, "&Signature=", erlcloud_http:url_encode(Signature)],
 

--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -116,49 +116,49 @@
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
 -include_lib("erlcloud/include/erlcloud_ec2.hrl").
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 ec2_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.
 
--spec(allocate_address/0 :: () -> string()).
+-spec allocate_address() -> string().
 allocate_address() -> allocate_address(default_config()).
 
--spec(allocate_address/1 :: (aws_config()) -> string()).
+-spec allocate_address(aws_config()) -> string().
 allocate_address(Config) ->
     Doc = ec2_query(Config, "AllocateAddress", []),
     get_text("/AllocateAddressResponse/publicIp", Doc).
 
--spec(associate_address/2 :: (string(), string()) -> ok).
+-spec associate_address(string(), string()) -> ok.
 associate_address(PublicIP, InstanceID) ->
     associate_address(PublicIP, InstanceID, default_config()).
 
--spec(associate_address/3 :: (string(), string(), aws_config()) -> ok).
+-spec associate_address(string(), string(), aws_config()) -> ok.
 associate_address(PublicIP, InstanceID, Config)
   when is_list(PublicIP), is_list(InstanceID) ->
     ec2_simple_query(Config, "AssociateAddress", [{"InstanceId", InstanceID}, {"PublicIp", PublicIP}]).
 
--spec(attach_volume/3 :: (string(), string(), string()) -> proplist()).
+-spec attach_volume(string(), string(), string()) -> proplist().
 attach_volume(VolumeID, InstanceID, Device) ->
     attach_volume(VolumeID, InstanceID, Device, default_config()).
 
--spec(attach_volume/4 :: (string(), string(), string(), aws_config()) -> proplist()).
+-spec attach_volume(string(), string(), string(), aws_config()) -> proplist().
 attach_volume(VolumeID, InstanceID, Device, Config)
   when is_list(VolumeID), is_list(InstanceID), is_list(Device) ->
     Doc = ec2_query(Config, "AttachVolume",
@@ -181,23 +181,23 @@ extract_volume_status(Node) ->
         Node
     ).
 
--spec(authorize_security_group_ingress/2 :: (string(), ec2_ingress_spec()) -> ok).
+-spec authorize_security_group_ingress(string(), ec2_ingress_spec()) -> ok.
 authorize_security_group_ingress(GroupName, IngressSpec) ->
     authorize_security_group_ingress(GroupName, IngressSpec, default_config()).
 
--spec(authorize_security_group_ingress/3 :: (string(), ec2_ingress_spec(), aws_config()) -> ok).
+-spec authorize_security_group_ingress(string(), ec2_ingress_spec(), aws_config()) -> ok.
 authorize_security_group_ingress(GroupName, IngressSpec, Config)
   when is_list(GroupName), is_record(IngressSpec, ec2_ingress_spec) ->
     Params = [{"GroupName", GroupName}|ingress_spec_params(IngressSpec)],
     ec2_simple_query(Config, "AuthorizeSecurityGroupIngress", Params).
 
--spec(bundle_instance/6 :: (string(), string(), string(), string(), string(), string()) -> proplist()).
+-spec bundle_instance(string(), string(), string(), string(), string(), string()) -> proplist().
 bundle_instance(InstanceID, Bucket, Prefix, AccessKeyID, UploadPolicy,
                 UploadPolicySignature) ->
     bundle_instance(InstanceID, Bucket, Prefix, AccessKeyID, UploadPolicy,
                 UploadPolicySignature, default_config()).
 
--spec(bundle_instance/7 :: (string(), string(), string(), string(), string(), string(), aws_config()) -> proplist()).
+-spec bundle_instance(string(), string(), string(), string(), string(), string(), aws_config()) -> proplist().
 bundle_instance(InstanceID, Bucket, Prefix, AccessKeyID, UploadPolicy,
                 UploadPolicySignature, Config) ->
     Doc = ec2_query(Config, "BundleInstance",
@@ -229,21 +229,21 @@ ingress_spec_params(Spec) ->
         {"CidrIp", Spec#ec2_ingress_spec.cidr_ip}
     ].
 
--spec(cancel_bundle_task/1 :: (string()) -> proplist()).
+-spec cancel_bundle_task(string()) -> proplist().
 cancel_bundle_task(BundleID) ->
     cancel_bundle_task(BundleID, default_config()).
 
--spec(cancel_bundle_task/2 :: (string(), aws_config()) -> proplist()).
+-spec cancel_bundle_task(string(), aws_config()) -> proplist().
 cancel_bundle_task(BundleID, Config)
   when is_list(BundleID) ->
     Doc = ec2_query(Config, "CancelBundleTask", [{"BundleId", BundleID}]),
     extract_bundle_task(xmerl_xpath:string("/CancelBundleTaskResponse/bundleInstanceTask", Doc)).
 
--spec(cancel_spot_instance_requests/1 :: ([string()]) -> [proplist()]).
+-spec cancel_spot_instance_requests([string()]) -> [proplist()].
 cancel_spot_instance_requests(SpotInstanceRequestIDs) ->
     cancel_spot_instance_requests(SpotInstanceRequestIDs, default_config()).
 
--spec(cancel_spot_instance_requests/2 :: ([string()], aws_config()) -> [proplist()]).
+-spec cancel_spot_instance_requests([string()], aws_config()) -> [proplist()].
 cancel_spot_instance_requests(SpotInstanceRequestIDs, Config)
   when is_list(SpotInstanceRequestIDs) ->
     Doc = ec2_query(Config, "CancelSpotInstanceRequests",
@@ -257,11 +257,11 @@ extract_spot_instance_state(Node) ->
         {state, get_text("state", Node)}
     ].
 
--spec(confirm_product_instance/2 :: (string(), string()) -> proplist()).
+-spec confirm_product_instance(string(), string()) -> proplist().
 confirm_product_instance(ProductCode, InstanceID) ->
     confirm_product_instance(ProductCode, InstanceID, default_config()).
 
--spec(confirm_product_instance/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec confirm_product_instance(string(), string(), aws_config()) -> proplist().
 confirm_product_instance(ProductCode, InstanceID, Config)
   when is_list(ProductCode), is_list(InstanceID) ->
     Params = [{"ProductCode", ProductCode}, {"InstanceId", InstanceID}],
@@ -271,10 +271,10 @@ confirm_product_instance(ProductCode, InstanceID, Config)
         {owner_id, get_text("/ConfirmProductInstanceResponse/ownerId", Doc)}
     ].
 
--spec(create_key_pair/1 :: (string()) -> proplist()).
+-spec create_key_pair(string()) -> proplist().
 create_key_pair(KeyName) -> create_key_pair(KeyName, default_config()).
 
--spec(create_key_pair/2 :: (string(), aws_config()) -> proplist()).
+-spec create_key_pair(string(), aws_config()) -> proplist().
 create_key_pair(KeyName, Config)
   when is_list(KeyName) ->
     Doc = ec2_query(Config, "CreateKeyPair", [{"KeyName", KeyName}]),
@@ -284,24 +284,24 @@ create_key_pair(KeyName, Config)
         {key_material, get_text("/CreateKeyPairResponse/keyMaterial", Doc)}
     ].
 
--spec(create_image/2 :: (string(), string()) -> proplist()).
+-spec create_image(string(), string()) -> proplist().
 create_image(InstanceID, Name) -> create_image(InstanceID, Name, default_config()).
 
--spec(create_image/3 :: (string(), string(), string() | aws_config()) -> proplist()).
+-spec create_image(string(), string(), string() | aws_config()) -> proplist().
 create_image(InstanceID, Name, Config)
   when is_record(Config, aws_config) ->
     create_image(InstanceID, Name, none, Config);
 create_image(InstanceID, Name, Description) ->
     create_image(InstanceID, Name, Description, default_config()).
 
--spec(create_image/4 :: (string(), string(), string() | none, boolean() | aws_config()) -> proplist()).
+-spec create_image(string(), string(), string() | none, boolean() | aws_config()) -> proplist().
 create_image(InstanceID, Name, Description, Config)
   when is_record(Config, aws_config) ->
     create_image(InstanceID, Name, Description, false, Config);
 create_image(InstanceID, Name, Description, NoReboot) ->
     create_image(InstanceID, Name, Description, NoReboot, default_config()).
 
--spec(create_image/5 :: (string(), string(), string() | none, boolean(), aws_config()) -> proplist()).
+-spec create_image(string(), string(), string() | none, boolean(), aws_config()) -> proplist().
 create_image(InstanceID, Name, Description, NoReboot, Config)
   when is_list(InstanceID), is_list(Name),
        is_list(Description) orelse Description =:= none,
@@ -311,28 +311,28 @@ create_image(InstanceID, Name, Description, NoReboot, Config)
     Doc = ec2_query(Config, "CreateImage", Params),
     [{image_id, get_text("/CreateImageResponse/imageId", Doc)}].
 
--spec(create_security_group/2 :: (string(), string()) -> ok).
+-spec create_security_group(string(), string()) -> ok.
 create_security_group(GroupName, GroupDescription) ->
     create_security_group(GroupName, GroupDescription, default_config()).
 
--spec(create_security_group/3 :: (string(), string(), aws_config()) -> ok).
+-spec create_security_group(string(), string(), aws_config()) -> ok.
 create_security_group(GroupName, GroupDescription, Config)
   when is_list(GroupName), is_list(GroupDescription) ->
     ec2_simple_query(Config, "CreateSecurityGroup",
         [{"GroupName", GroupName}, {"GroupDescription", GroupDescription}]).
 
--spec(create_snapshot/1 :: (string()) -> proplist()).
+-spec create_snapshot(string()) -> proplist().
 create_snapshot(VolumeID) ->
     create_snapshot(VolumeID, "", default_config()).
 
--spec(create_snapshot/2 :: (string(), string()) -> proplist() ; (string(), aws_config()) -> proplist()).
+-spec create_snapshot(string(), string()) -> proplist() ; (string(), aws_config()) -> proplist().
 create_snapshot(VolumeID, Config)
   when is_record(Config, aws_config) ->
     create_snapshot(VolumeID, "", Config);
 create_snapshot(VolumeID, Description) ->
     create_snapshot(VolumeID, Description, default_config()).
 
--spec(create_snapshot/3 :: (string(), string(), aws_config()) -> proplist()).
+-spec create_snapshot(string(), string(), aws_config()) -> proplist().
 create_snapshot(VolumeID, Description, Config)
   when is_list(VolumeID), is_list(Description) ->
     Doc = ec2_query(Config, "CreateSnapshot",
@@ -351,18 +351,18 @@ create_snapshot(VolumeID, Description, Config)
         {description, get_text("/CreateSnapshotResponse/description", Doc)}
     ].
 
--spec(create_spot_datafeed_subscription/1 :: (string()) -> proplist()).
+-spec create_spot_datafeed_subscription(string()) -> proplist().
 create_spot_datafeed_subscription(Bucket) ->
     create_spot_datafeed_subscription(Bucket, none).
 
--spec(create_spot_datafeed_subscription/2 :: (string(), string() | none | aws_config()) -> proplist()).
+-spec create_spot_datafeed_subscription(string(), string() | none | aws_config()) -> proplist().
 create_spot_datafeed_subscription(Bucket, Config)
   when is_record(Config, aws_config) ->
     create_spot_datafeed_subscription(Bucket, none, Config);
 create_spot_datafeed_subscription(Bucket, Prefix) ->
     create_spot_datafeed_subscription(Bucket, Prefix, default_config()).
 
--spec(create_spot_datafeed_subscription/3 :: (string(), string() | none, aws_config()) -> proplist()).
+-spec create_spot_datafeed_subscription(string(), string() | none, aws_config()) -> proplist().
 create_spot_datafeed_subscription(Bucket, Prefix, Config)
   when is_list(Bucket),
        is_list(Prefix) orelse Prefix =:= none ->
@@ -381,11 +381,11 @@ extract_spot_datafeed_subscription([Node]) ->
                 ]}
     ].
 
--spec(create_volume/3 :: (ec2_volume_size(), string(), string()) -> proplist()).
+-spec create_volume(ec2_volume_size(), string(), string()) -> proplist().
 create_volume(Size, SnapshotID, AvailabilityZone) ->
     create_volume(Size, SnapshotID, AvailabilityZone, default_config()).
 
--spec(create_volume/4 :: (ec2_volume_size(), string(), string(), aws_config()) -> proplist()).
+-spec create_volume(ec2_volume_size(), string(), string(), aws_config()) -> proplist().
 create_volume(Size, SnapshotID, AvailabilityZone, Config)
   when Size >= 1, Size =< 1024,
        is_list(SnapshotID) orelse SnapshotID =:= none,
@@ -404,79 +404,79 @@ create_volume(Size, SnapshotID, AvailabilityZone, Config)
      {create_time, erlcloud_xml:get_time("createTime", Doc)}
     ].
 
--spec(delete_key_pair/1 :: (string()) -> ok).
+-spec delete_key_pair(string()) -> ok.
 delete_key_pair(KeyName) -> delete_key_pair(KeyName, default_config()).
 
--spec(delete_key_pair/2 :: (string(), aws_config()) -> ok).
+-spec delete_key_pair(string(), aws_config()) -> ok.
 delete_key_pair(KeyName, Config)
   when is_list(KeyName) ->
     ec2_simple_query(Config, "DeleteKeyPair", [{"KeyName", KeyName}]).
 
--spec(delete_security_group/1 :: (string()) -> ok).
+-spec delete_security_group(string()) -> ok.
 delete_security_group(GroupName) -> delete_security_group(GroupName, default_config()).
 
--spec(delete_security_group/2 :: (string(), aws_config()) -> ok).
+-spec delete_security_group(string(), aws_config()) -> ok.
 delete_security_group(GroupName, Config)
   when is_list(GroupName) ->
     ec2_simple_query(Config, "DeleteSecurityGroup", [{"GroupName", GroupName}]).
 
--spec(delete_snapshot/1 :: (string()) -> ok).
+-spec delete_snapshot(string()) -> ok.
 delete_snapshot(SnapshotID) -> delete_snapshot(SnapshotID, default_config()).
 
--spec(delete_snapshot/2 :: (string(), aws_config()) -> ok).
+-spec delete_snapshot(string(), aws_config()) -> ok.
 delete_snapshot(SnapshotID, Config)
   when is_list(SnapshotID) ->
     ec2_simple_query(Config, "DeleteSnapshot", [{"SnapshotId", SnapshotID}]).
 
--spec(delete_spot_datafeed_subscription/0 :: () -> ok).
+-spec delete_spot_datafeed_subscription() -> ok.
 delete_spot_datafeed_subscription() -> delete_spot_datafeed_subscription(default_config()).
 
--spec(delete_spot_datafeed_subscription/1 :: (aws_config()) -> ok).
+-spec delete_spot_datafeed_subscription(aws_config()) -> ok.
 delete_spot_datafeed_subscription(Config) ->
     ec2_simple_query(Config, "DeleteSpotDatafeedSubscription", []).
 
--spec(delete_volume/1 :: (string()) -> ok).
+-spec delete_volume(string()) -> ok.
 delete_volume(VolumeID) -> delete_volume(VolumeID, default_config()).
 
--spec(delete_volume/2 :: (string(), aws_config()) -> ok).
+-spec delete_volume(string(), aws_config()) -> ok.
 delete_volume(VolumeID, Config)
   when is_list(VolumeID) ->
     ec2_simple_query(Config, "DeleteVolume", [{"VolumeId", VolumeID}]).
 
--spec(deregister_image/1 :: (string()) -> ok).
+-spec deregister_image(string()) -> ok.
 deregister_image(ImageID) -> deregister_image(ImageID, default_config()).
 
--spec(deregister_image/2 :: (string(), aws_config()) -> ok).
+-spec deregister_image(string(), aws_config()) -> ok.
 deregister_image(ImageID, Config)
   when is_list(ImageID) ->
     ec2_simple_query(Config, "DeregisterImage", [{"ImageId", ImageID}]).
 
--spec(describe_addresses/0 :: () -> proplist()).
+-spec describe_addresses() -> proplist().
 describe_addresses() -> describe_addresses([]).
 
--spec(describe_addresses/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_addresses([string()] | aws_config()) -> proplist().
 describe_addresses(Config)
   when is_record(Config, aws_config) ->
     describe_addresses([], Config);
 describe_addresses(PublicIPs) -> describe_addresses(PublicIPs, default_config()).
 
--spec(describe_addresses/2 :: ([string()], aws_config()) -> proplist()).
+-spec describe_addresses([string()], aws_config()) -> proplist().
 describe_addresses(PublicIPs, Config)
   when is_list(PublicIPs) ->
     Doc = ec2_query(Config, "DescribeAddresses", erlcloud_aws:param_list(PublicIPs, "PublicIp")),
     Items = xmerl_xpath:string("/DescribeAddressesResponse/addressesSet/item", Doc),
     [[{public_ip, get_text("publicIp", Item)}, {instance_id, get_text("instanceId", Item, none)}] || Item <- Items].
 
--spec(describe_availability_zones/0 :: () -> proplist()).
+-spec describe_availability_zones() -> proplist().
 describe_availability_zones() -> describe_availability_zones([]).
--spec(describe_availability_zones/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_availability_zones([string()] | aws_config()) -> proplist().
 describe_availability_zones(Config)
   when is_record(Config, aws_config) ->
     describe_availability_zones([], Config);
 describe_availability_zones(ZoneNames) ->
     describe_availability_zones(ZoneNames, default_config()).
 
--spec(describe_availability_zones/2 :: ([string()], aws_config()) -> proplist()).
+-spec describe_availability_zones([string()], aws_config()) -> proplist().
 describe_availability_zones(ZoneNames, Config)
   when is_list(ZoneNames) ->
     Doc = ec2_query(Config, "DescribeAvailabilityZones", erlcloud_aws:param_list(ZoneNames, "ZoneName")),
@@ -487,27 +487,27 @@ describe_availability_zones(ZoneNames, Config)
       {messages, get_list("messageSet/item/message", Item)}
      ] || Item <- Items].
 
--spec(describe_bundle_tasks/0 :: () -> [proplist()]).
+-spec describe_bundle_tasks() -> [proplist()].
 describe_bundle_tasks() ->
     describe_bundle_tasks([]).
 
--spec(describe_bundle_tasks/1 :: ([string()] | aws_config()) -> [proplist()]).
+-spec describe_bundle_tasks([string()] | aws_config()) -> [proplist()].
 describe_bundle_tasks(Config)
   when is_record(Config, aws_config) ->
     describe_bundle_tasks([], Config);
 describe_bundle_tasks(BundleIDs) ->
     describe_bundle_tasks(BundleIDs, default_config()).
 
--spec(describe_bundle_tasks/2 :: ([string()], aws_config()) -> [proplist()]).
+-spec describe_bundle_tasks([string()], aws_config()) -> [proplist()].
 describe_bundle_tasks(BundleIDs, Config) ->
     Doc = ec2_query(Config, "DescribeBundleTasks", erlcloud_aws:param_list(BundleIDs, "BundleId")),
     [extract_bundle_task(Item) || Item <- xmerl_xpath:string("/DescribeBundleTasksResponse/bundleInstanceTasksSet/item", Doc)].
 
--spec(describe_image_attribute/2 :: (string(), atom()) -> proplist()).
+-spec describe_image_attribute(string(), atom()) -> proplist().
 describe_image_attribute(ImageID, Attribute) ->
     describe_image_attribute(ImageID, Attribute, default_config()).
 
--spec(describe_image_attribute/3 :: (string(), atom(), aws_config()) -> term()).
+-spec describe_image_attribute(string(), atom(), aws_config()) -> term().
 describe_image_attribute(ImageID, Attribute, Config)
   when is_list(ImageID), is_atom(Attribute) ->
     AttributeName = case Attribute of
@@ -537,17 +537,17 @@ extract_permissions([#xmlElement{name="userId"} = Node|Nodes], Accum) ->
 extract_permissions([_|Nodes], Accum) ->
     extract_permissions(Nodes, Accum).
 
--spec(describe_images/0 :: () -> proplist()).
+-spec describe_images() -> proplist().
 describe_images() -> describe_images([], "self").
 
--spec(describe_images/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_images([string()] | aws_config()) -> proplist().
 describe_images(Config)
   when is_record(Config, aws_config) ->
     describe_images([], "self", none, Config);
 describe_images(ImageIDs) ->
     describe_images(ImageIDs, none, none, default_config()).
 
--spec(describe_images/2 :: ([string()], aws_config()) -> proplist() ;
+-spec(describe_images([string()], aws_config()) -> proplist() ;
                            ([string()], string() | none) -> proplist()).
 describe_images(ImageIDs, Config)
   when is_record(Config, aws_config) ->
@@ -555,7 +555,7 @@ describe_images(ImageIDs, Config)
 describe_images(ImageIDs, Owner) ->
     describe_images(ImageIDs, Owner, none, default_config()).
 
--spec(describe_images/3 :: ([string()], string() | none, aws_config()) -> proplist() ;
+-spec(describe_images([string()], string() | none, aws_config()) -> proplist() ;
                            ([string()], string() | none, string() | none) -> proplist()).
 describe_images(ImageIDs, Owner, Config)
   when is_record(Config, aws_config) ->
@@ -563,7 +563,7 @@ describe_images(ImageIDs, Owner, Config)
 describe_images(ImageIDs, Owner, ExecutableBy) ->
     describe_images(ImageIDs, Owner, ExecutableBy, default_config()).
 
--spec(describe_images/4 :: ([string()], string() | none, string() | none, aws_config()) -> proplist  ()).
+-spec describe_images([string()], string() | none, string() | none, aws_config()) -> proplist  ().
 describe_images(ImageIDs, Owner, ExecutableBy, Config)
   when is_list(ImageIDs),
         is_list(Owner) orelse Owner =:= none,
@@ -602,11 +602,11 @@ extract_block_device_mapping(Node) ->
         delete_on_termination=get_bool("ebs/deleteOnTermination", Node)
     }.
 
--spec(describe_instance_attribute/2 :: (string(), atom()) -> proplist()).
+-spec describe_instance_attribute(string(), atom()) -> proplist().
 describe_instance_attribute(InstanceID, Attribute) ->
     describe_instance_attribute(InstanceID, Attribute, default_config()).
 
--spec(describe_instance_attribute/3 :: (string(), atom(), aws_config()) -> term()).
+-spec describe_instance_attribute(string(), atom(), aws_config()) -> term().
 describe_instance_attribute(InstanceID, Attribute, Config)
   when is_list(InstanceID), is_atom(Attribute) ->
     AttributeName = case Attribute of
@@ -633,17 +633,17 @@ describe_instance_attribute(InstanceID, Attribute, Config)
         _ -> get_text(Node)
     end.
 
--spec(describe_instances/0 :: () -> proplist()).
+-spec describe_instances() -> proplist().
 describe_instances() -> describe_instances([]).
 
--spec(describe_instances/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_instances([string()] | aws_config()) -> proplist().
 describe_instances(Config)
   when is_record(Config, aws_config) ->
     describe_instances([], Config);
 describe_instances(InstanceIDs) ->
     describe_instances(InstanceIDs, default_config()).
 
--spec(describe_instances/2 :: ([string()], aws_config()) -> proplist()).
+-spec describe_instances([string()], aws_config()) -> proplist().
 describe_instances(InstanceIDs, Config)
   when is_list(InstanceIDs) ->
     Doc = ec2_query(Config, "DescribeInstances", erlcloud_aws:param_list(InstanceIDs, "InstanceId")),
@@ -698,16 +698,16 @@ extract_block_device_mapping_status(Node) ->
         {delete_on_termination, get_bool("ebs/deleteOnTermination", Node)}
     ].
 
--spec(describe_key_pairs/0 :: () -> proplist()).
+-spec describe_key_pairs() -> proplist().
 describe_key_pairs() -> describe_key_pairs([]).
 
--spec(describe_key_pairs/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_key_pairs([string()] | aws_config()) -> proplist().
 describe_key_pairs(Config)
   when is_record(Config, aws_config) ->
     describe_key_pairs([], Config);
 describe_key_pairs(KeyNames) -> describe_key_pairs(KeyNames, default_config()).
 
--spec(describe_key_pairs/2 :: ([string()], aws_config()) -> proplist()).
+-spec describe_key_pairs([string()], aws_config()) -> proplist().
 describe_key_pairs(KeyNames, Config)
   when is_list(KeyNames) ->
     Doc = ec2_query(Config, "DescribeKeyPairs", erlcloud_aws:param_list(KeyNames, "KeyName")),
@@ -719,16 +719,16 @@ describe_key_pairs(KeyNames, Config)
         ] || Item <- Items
     ].
 
--spec(describe_regions/0 :: () -> proplist()).
+-spec describe_regions() -> proplist().
 describe_regions() -> describe_regions([]).
--spec(describe_regions/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_regions([string()] | aws_config()) -> proplist().
 describe_regions(Config)
   when is_record(Config, aws_config) ->
     describe_regions([], Config);
 describe_regions(RegionNames) ->
     describe_regions(RegionNames, default_config()).
 
--spec(describe_regions/2 :: ([string()], aws_config()) -> proplist()).
+-spec describe_regions([string()], aws_config()) -> proplist().
 describe_regions(RegionNames, Config)
   when is_list(RegionNames) ->
     Doc = ec2_query(Config, "DescribeRegions", erlcloud_aws:param_list(RegionNames, "RegionName")),
@@ -737,17 +737,17 @@ describe_regions(RegionNames, Config)
       {region_endpoint, get_text("regionEndpoint", Item)}
      ] || Item <- Items].
 
--spec(describe_reserved_instances/0 :: () -> proplist()).
+-spec describe_reserved_instances() -> proplist().
 describe_reserved_instances() -> describe_reserved_instances([]).
 
--spec(describe_reserved_instances/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_reserved_instances([string()] | aws_config()) -> proplist().
 describe_reserved_instances(Config)
   when is_record(Config, aws_config) ->
     describe_reserved_instances([], Config);
 describe_reserved_instances(ReservedInstanceIDs) ->
     describe_reserved_instances(ReservedInstanceIDs, default_config()).
 
--spec(describe_reserved_instances/2 :: ([string()], aws_config()) -> proplist()).
+-spec describe_reserved_instances([string()], aws_config()) -> proplist().
 describe_reserved_instances(ReservedInstanceIDs, Config)
   when is_list(ReservedInstanceIDs) ->
     Doc = ec2_query(Config, "DescribeReservedInstances", erlcloud_aws:param_list(ReservedInstanceIDs, "ReservedInstanceId")),
@@ -768,17 +768,17 @@ extract_reserved_instance(Node) ->
         {state, get_text("state", Node)}
     ].
 
--spec(describe_reserved_instances_offerings/0 :: () -> proplist()).
+-spec describe_reserved_instances_offerings() -> proplist().
 describe_reserved_instances_offerings() -> describe_reserved_instances_offerings([]).
 
--spec(describe_reserved_instances_offerings/1 :: ([{atom(), string()}] | aws_config()) -> proplist()).
+-spec describe_reserved_instances_offerings([{atom(), string()}] | aws_config()) -> proplist().
 describe_reserved_instances_offerings(Config)
   when is_record(Config, aws_config) ->
     describe_reserved_instances_offerings([], Config);
 describe_reserved_instances_offerings(Selector) ->
     describe_reserved_instances_offerings(Selector, default_config()).
 
--spec(describe_reserved_instances_offerings/2 :: ([{atom(), string()}], aws_config()) -> proplist()).
+-spec describe_reserved_instances_offerings([{atom(), string()}], aws_config()) -> proplist().
 describe_reserved_instances_offerings(Selector, Config)
   when is_list(Selector) ->
     InstanceTypes = [Value || {Key, Value} <- Selector, Key =:= instance_type],
@@ -802,18 +802,18 @@ extract_reserved_instances_offering(Node) ->
         {product_description, get_text("productDescription", Node)}
     ].
 
--spec(describe_security_groups/0 :: () -> [proplist()]).
+-spec describe_security_groups() -> [proplist()].
 describe_security_groups() ->
     describe_security_groups([]).
 
--spec(describe_security_groups/1 :: ([string()] | aws_config()) -> [proplist()]).
+-spec describe_security_groups([string()] | aws_config()) -> [proplist()].
 describe_security_groups(Config)
   when is_record(Config, aws_config) ->
     describe_security_groups([], Config);
 describe_security_groups(GroupNames) ->
     describe_security_groups(GroupNames, default_config()).
 
--spec(describe_security_groups/2 :: ([string()], aws_config()) -> [proplist()]).
+-spec describe_security_groups([string()], aws_config()) -> [proplist()].
 describe_security_groups(GroupNames, Config)
   when is_list(GroupNames) ->
     Doc = ec2_query(Config, "DescribeSecurityGroups", erlcloud_aws:param_list(GroupNames, "GroupName")),
@@ -838,27 +838,27 @@ extract_ip_permissions(Node) ->
         {ip_ranges, get_list("ipRanges/item/cidrIp", Node)}
     ].
 
--spec(describe_snapshot_attribute/2 :: (string(), atom()) -> proplist()).
+-spec describe_snapshot_attribute(string(), atom()) -> proplist().
 describe_snapshot_attribute(SnapshotID, Attribute) ->
     describe_snapshot_attribute(SnapshotID, Attribute, default_config()).
 
--spec(describe_snapshot_attribute/3 :: (string(), atom(), aws_config()) -> term()).
+-spec describe_snapshot_attribute(string(), atom(), aws_config()) -> term().
 describe_snapshot_attribute(SnapshotID, create_volume_permission, Config)
   when is_list(SnapshotID) ->
     Doc = ec2_query(Config, "DescribeSnapshotAttribute", [{"snapshotId", SnapshotID}, {"Attribute", "createVolumePermission"}]),
     extract_permissions(xmerl_xpath:string("/DescribeSnapshotAttributeResponse/createVolumePermission/item", Doc)).
 
--spec(describe_snapshots/0 :: () -> [proplist()]).
+-spec describe_snapshots() -> [proplist()].
 describe_snapshots() -> describe_snapshots([], "self").
 
--spec(describe_snapshots/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_snapshots([string()] | aws_config()) -> proplist().
 describe_snapshots(Config)
   when is_record(Config, aws_config) ->
     describe_snapshots([], "self", Config);
 describe_snapshots(SnapshotIDs) ->
     describe_snapshots(SnapshotIDs, none, none, default_config()).
 
--spec(describe_snapshots/2 :: ([string()], aws_config()) -> [proplist()] ;
+-spec(describe_snapshots([string()], aws_config()) -> [proplist()] ;
                               ([string()], string() | none) -> [proplist()]).
 describe_snapshots(SnapshotIDs, Config)
   when is_record(Config, aws_config) ->
@@ -866,7 +866,7 @@ describe_snapshots(SnapshotIDs, Config)
 describe_snapshots(SnapshotIDs, Owner) ->
     describe_snapshots(SnapshotIDs, Owner, none, default_config()).
 
--spec(describe_snapshots/3 :: ([string()], string() | none, aws_config()) -> [proplist()] ;
+-spec(describe_snapshots([string()], string() | none, aws_config()) -> [proplist()] ;
                               ([string()], string() | none, string() | none) -> [proplist()]).
 describe_snapshots(SnapshotIDs, Owner, Config)
   when is_record(Config, aws_config) ->
@@ -874,7 +874,7 @@ describe_snapshots(SnapshotIDs, Owner, Config)
 describe_snapshots(SnapshotIDs, Owner, RestorableBy) ->
     describe_snapshots(SnapshotIDs, Owner, RestorableBy, default_config()).
 
--spec(describe_snapshots/4 :: ([string()], string() | none, string() | none, aws_config()) -> [proplist()]).
+-spec describe_snapshots([string()], string() | none, string() | none, aws_config()) -> [proplist()].
 describe_snapshots(SnapshotIDs, Owner, RestorableBy, Config)
   when is_list(SnapshotIDs),
        is_list(Owner) orelse Owner =:= none,
@@ -896,27 +896,27 @@ extract_snapshot(Node) ->
      {owner_alias, get_text("ownerAlias", Node, none)}
     ].
 
--spec(describe_spot_datafeed_subscription/0 :: () -> proplist()).
+-spec describe_spot_datafeed_subscription() -> proplist().
 describe_spot_datafeed_subscription() ->
     describe_spot_datafeed_subscription(default_config()).
 
--spec(describe_spot_datafeed_subscription/1 :: (aws_config()) -> proplist()).
+-spec describe_spot_datafeed_subscription(aws_config()) -> proplist().
 describe_spot_datafeed_subscription(Config) ->
     Doc = ec2_query(Config, "DescribeSpotDatafeedSubscription", []),
     extract_spot_datafeed_subscription(xmerl_xpath:string("/DescribeSpotDatafeedSubscriptionResponse/spotDatafeedSubscription", Doc)).
 
--spec(describe_spot_instance_requests/0 :: () -> [proplist()]).
+-spec describe_spot_instance_requests() -> [proplist()].
 describe_spot_instance_requests() ->
     describe_spot_instance_requests([]).
 
--spec(describe_spot_instance_requests/1 :: ([string()] | aws_config()) -> [proplist()]).
+-spec describe_spot_instance_requests([string()] | aws_config()) -> [proplist()].
 describe_spot_instance_requests(Config)
   when is_record(Config, aws_config) ->
     describe_spot_instance_requests([], Config);
 describe_spot_instance_requests(SpotInstanceRequestIDs) ->
     describe_spot_instance_requests(SpotInstanceRequestIDs, default_config()).
 
--spec(describe_spot_instance_requests/2 :: ([string()], aws_config()) -> [proplist()]).
+-spec describe_spot_instance_requests([string()], aws_config()) -> [proplist()].
 describe_spot_instance_requests(SpotInstanceRequestIDs, Config)
   when is_list(SpotInstanceRequestIDs) ->
     Doc = ec2_query(Config, "DescribeSpotInstanceRequests",
@@ -959,32 +959,32 @@ extract_launch_specification(Node) ->
         {subnet_id, get_text("subnetId", Node)}
     ].
 
--spec(describe_spot_price_history/0 :: () -> proplist()).
+-spec describe_spot_price_history() -> proplist().
 describe_spot_price_history() ->
     describe_spot_price_history(none).
 
--spec(describe_spot_price_history/1 :: (datetime() | none | aws_config()) -> proplist()).
+-spec describe_spot_price_history(datetime() | none | aws_config()) -> proplist().
 describe_spot_price_history(Config)
   when is_record(Config, aws_config) ->
     describe_spot_price_history(none, Config);
 describe_spot_price_history(StartTime) ->
     describe_spot_price_history(StartTime, none).
 
--spec(describe_spot_price_history/2 :: (datetime() | none, datetime() | none | aws_config()) -> proplist()).
+-spec describe_spot_price_history(datetime() | none, datetime() | none | aws_config()) -> proplist().
 describe_spot_price_history(StartTime, Config)
   when is_record(Config, aws_config) ->
     describe_spot_price_history(StartTime, none, Config);
 describe_spot_price_history(StartTime, EndTime) ->
     describe_spot_price_history(StartTime, EndTime, []).
 
--spec(describe_spot_price_history/3 :: (datetime() | none, datetime() | none, [string()] | aws_config()) -> proplist()).
+-spec describe_spot_price_history(datetime() | none, datetime() | none, [string()] | aws_config()) -> proplist().
 describe_spot_price_history(StartTime, EndTime, Config)
   when is_record(Config, aws_config) ->
     describe_spot_price_history(StartTime, EndTime, [], Config);
 describe_spot_price_history(StartTime, EndTime, InstanceTypes) ->
     describe_spot_price_history(StartTime, EndTime, InstanceTypes, none).
 
--spec(describe_spot_price_history/4 :: (datetime() | none, datetime() | none, [string()], string() | none | aws_config()) -> proplist()).
+-spec describe_spot_price_history(datetime() | none, datetime() | none, [string()], string() | none | aws_config()) -> proplist().
 describe_spot_price_history(StartTime, EndTime, InstanceTypes, Config)
   when is_record(Config, aws_config) ->
     describe_spot_price_history(StartTime, EndTime, InstanceTypes, none, Config);
@@ -992,7 +992,7 @@ describe_spot_price_history(StartTime, EndTime, InstanceTypes, ProductDescriptio
     describe_spot_price_history(StartTime, EndTime, InstanceTypes,
                                 ProductDescription, default_config()).
 
--spec(describe_spot_price_history/5 :: (datetime() | none, datetime() | none, [string()], string() | none, aws_config()) -> proplist()).
+-spec describe_spot_price_history(datetime() | none, datetime() | none, [string()], string() | none, aws_config()) -> proplist().
 describe_spot_price_history(StartTime, EndTime, InstanceTypes,
                             ProductDescription, Config)
   when is_list(InstanceTypes),
@@ -1012,17 +1012,17 @@ extract_spot_price_history(Node) ->
         {timestamp, erlcloud_xml:get_time("timestamp", Node)}
     ].
 
--spec(describe_volumes/0 :: () -> proplist()).
+-spec describe_volumes() -> proplist().
 describe_volumes() -> describe_volumes([]).
 
--spec(describe_volumes/1 :: ([string()] | aws_config()) -> proplist()).
+-spec describe_volumes([string()] | aws_config()) -> proplist().
 describe_volumes(Config)
   when is_record(Config, aws_config) ->
     describe_volumes([], Config);
 describe_volumes(VolumeIDs) ->
     describe_volumes(VolumeIDs, default_config()).
 
--spec(describe_volumes/2 :: ([string()], aws_config()) -> proplist()).
+-spec describe_volumes([string()], aws_config()) -> proplist().
 describe_volumes(VolumeIDs, Config)
   when is_list(VolumeIDs) ->
     Doc = ec2_query(Config, "DescribeVolumes", erlcloud_aws:param_list(VolumeIDs, "VolumeId")),
@@ -1047,29 +1047,29 @@ extract_volume(Node) ->
      }
     ].
 
--spec(detach_volume/1 :: (string()) -> proplist()).
+-spec detach_volume(string()) -> proplist().
 detach_volume(VolumeID) -> detach_volume(VolumeID, default_config()).
 
--spec(detach_volume/2 :: (string(), aws_config()) -> proplist()).
+-spec detach_volume(string(), aws_config()) -> proplist().
 detach_volume(VolumeID, Config)
   when is_list(VolumeID) ->
     Params = [{"VolumeId", VolumeID}],
     Doc = ec2_query(Config, "DetachVolume", Params),
     extract_volume_status(hd(xmerl_xpath:string("/DetachVolumeResponse", Doc))).
 
--spec(disassociate_address/1 :: (string()) -> ok).
+-spec disassociate_address(string()) -> ok.
 disassociate_address(PublicIP) ->
     disassociate_address(PublicIP, default_config()).
 
--spec(disassociate_address/2 :: (string(), aws_config()) -> ok).
+-spec disassociate_address(string(), aws_config()) -> ok.
 disassociate_address(PublicIP, Config)
   when is_list(PublicIP) ->
     ec2_simple_query(Config, "DisassociateAddress", [{"PublicIp", PublicIP}]).
 
--spec(get_console_output/1 :: (string()) -> proplist()).
+-spec get_console_output(string()) -> proplist().
 get_console_output(InstanceID) -> get_console_output(InstanceID, default_config()).
 
--spec(get_console_output/2 :: (string(), aws_config()) -> proplist()).
+-spec get_console_output(string(), aws_config()) -> proplist().
 get_console_output(InstanceID, Config)
   when is_list(InstanceID) ->
     Doc = ec2_query(Config, "GetConsoleOutput", [{"InstanceId", InstanceID}]),
@@ -1078,10 +1078,10 @@ get_console_output(InstanceID, Config)
      {output, base64:decode(get_text("/GetConsoleOutputResponse/output", Doc))}
     ].
 
--spec(get_password_data/1 :: (string()) -> proplist()).
+-spec get_password_data(string()) -> proplist().
 get_password_data(InstanceID) -> get_password_data(InstanceID, default_config()).
 
--spec(get_password_data/2 :: (string(), aws_config()) -> proplist()).
+-spec get_password_data(string(), aws_config()) -> proplist().
 get_password_data(InstanceID, Config)
   when is_list(InstanceID) ->
     Doc = ec2_query(Config, "GetPasswordData", [{"InstanceId", InstanceID}]),
@@ -1090,11 +1090,11 @@ get_password_data(InstanceID, Config)
      {password_data, get_text("/GetPasswordDataResponse/passwordData", Doc)}
     ].
 
--spec(modify_image_attribute/3 :: (string(), atom(), term()) -> ok).
+-spec modify_image_attribute(string(), atom(), term()) -> ok.
 modify_image_attribute(ImageID, Attribute, Value) ->
     modify_image_attribute(ImageID, Attribute, Value, default_config()).
 
--spec(modify_image_attribute/4 :: (string(), atom(), term(), aws_config()) -> ok).
+-spec modify_image_attribute(string(), atom(), term(), aws_config()) -> ok.
 modify_image_attribute(ImageID, Attribute, Value, Config) ->
     {AttributeName, OperationType, Values} = case {Attribute, Value} of
         {launch_permission, {Operation, Permissions}}
@@ -1114,11 +1114,11 @@ modify_image_attribute(ImageID, Attribute, Value, Config) ->
              ],
     ec2_simple_query(Config, "ModifyImageAttribute", Params).
 
--spec(modify_instance_attribute/3 :: (string(), atom(), term()) -> ok).
+-spec modify_instance_attribute(string(), atom(), term()) -> ok.
 modify_instance_attribute(InstanceID, Attribute, Value) ->
     modify_instance_attribute(InstanceID, Attribute, Value, default_config()).
 
--spec(modify_instance_attribute/4 :: (string(), atom(), term(), aws_config()) -> ok).
+-spec modify_instance_attribute(string(), atom(), term(), aws_config()) -> ok.
 modify_instance_attribute(InstanceID, Attribute, Value, Config) ->
     {AttributeName, AParams} = case Attribute of
         instance_type when is_list(Value) -> {"instanceType", [{"Value", Value}]};
@@ -1142,11 +1142,11 @@ permission_list(Permissions) ->
     Groups = [Group || {group, Group} <- Permissions],
     erlcloud_aws:param_list(UserIDs, "UserId") ++ erlcloud_aws:param_list(Groups, "Group").
 
--spec(modify_snapshot_attribute/3 :: (string(), atom(), term()) -> ok).
+-spec modify_snapshot_attribute(string(), atom(), term()) -> ok.
 modify_snapshot_attribute(SnapshotID, Attribute, Value) ->
     modify_snapshot_attribute(SnapshotID, Attribute, Value, default_config()).
 
--spec(modify_snapshot_attribute/4 :: (string(), atom(), term(), aws_config()) -> ok).
+-spec modify_snapshot_attribute(string(), atom(), term(), aws_config()) -> ok.
 modify_snapshot_attribute(SnapshotID, create_volume_permission,
                           {Operation, Permissions}, Config)
   when Operation =:= add orelse Operation =:= remove,
@@ -1158,11 +1158,11 @@ modify_snapshot_attribute(SnapshotID, create_volume_permission,
              ],
     ec2_simple_query(Config, "ModifySnapshotAttribute", Params).
 
--spec(monitor_instances/1 :: ([string()]) -> proplist()).
+-spec monitor_instances([string()]) -> proplist().
 monitor_instances(InstanceIDs) ->
     monitor_instances(InstanceIDs, default_config()).
 
--spec(monitor_instances/2 :: ([string()], aws_config()) -> [proplist()]).
+-spec monitor_instances([string()], aws_config()) -> [proplist()].
 monitor_instances(InstanceIDs, Config) ->
     Doc = ec2_query(Config, "MonitorInstances", erlcloud_aws:param_list(InstanceIDs, "InstanceId")),
     [extract_monitor_state(Node) || Node <- xmerl_xpath:string("/MonitorInstancesResponse/instancesSet/item", Doc)].
@@ -1173,11 +1173,11 @@ extract_monitor_state(Node) ->
         {monitoring_state, get_text("monitoring/state", Node)}
     ].
 
--spec(purchase_reserved_instances_offering/1 :: ([string() | {string(), pos_integer()}]) -> [string()]).
+-spec purchase_reserved_instances_offering([string() | {string(), pos_integer()}]) -> [string()].
 purchase_reserved_instances_offering(ReservedInstancesOfferings) ->
     purchase_reserved_instances_offering(ReservedInstancesOfferings, default_config()).
 
--spec(purchase_reserved_instances_offering/2 :: ([string() | {string(), pos_integer()}], aws_config()) -> [string()]).
+-spec purchase_reserved_instances_offering([string() | {string(), pos_integer()}], aws_config()) -> [string()].
 purchase_reserved_instances_offering(ReservedInstancesOfferings, Config)
   when is_list(ReservedInstancesOfferings), length(ReservedInstancesOfferings) > 0 ->
     Params = lists:flatten(
@@ -1194,18 +1194,18 @@ purchase_reserved_instances_offering(ReservedInstancesOfferings, Config)
     Doc = ec2_query(Config, "PurchaseReservedInstancesOffering", Params),
     get_list("/PurchaseReservedInstancesOfferingResponse/reservedInstancesId", Doc).
 
--spec(reboot_instances/1 :: ([string()]) -> ok).
+-spec reboot_instances([string()]) -> ok.
 reboot_instances(InstanceIDs) -> reboot_instances(InstanceIDs, default_config()).
 
--spec(reboot_instances/2 :: ([string()], aws_config()) -> ok).
+-spec reboot_instances([string()], aws_config()) -> ok.
 reboot_instances(InstanceIDs, Config)
   when is_list(InstanceIDs) ->
     ec2_simple_query(Config, "RebootInstances", erlcloud_aws:param_list(InstanceIDs, "InstanceId")).
 
--spec(register_image/1 :: (ec2_image_spec()) -> proplist()).
+-spec register_image(ec2_image_spec()) -> proplist().
 register_image(ImageSpec) -> register_image(ImageSpec, default_config()).
 
--spec(register_image/2 :: (ec2_image_spec(), aws_config()) -> proplist()).
+-spec register_image(ec2_image_spec(), aws_config()) -> proplist().
 register_image(ImageSpec, Config) ->
     Params = [
         {"ImageLocation", ImageSpec#ec2_image_spec.image_location},
@@ -1220,14 +1220,14 @@ register_image(ImageSpec, Config) ->
     Doc = ec2_query(Config, "RegisterImage", Params ++ BDParams),
     [{image_id, get_text("/CreateImageResponse/imageId", Doc)}].
 
--spec(release_address/1 :: (string()) -> ok).
+-spec release_address(string()) -> ok.
 release_address(PublicIP) -> release_address(PublicIP, default_config()).
 
--spec(request_spot_instances/1 :: (ec2_spot_instance_request()) -> [proplist()]).
+-spec request_spot_instances(ec2_spot_instance_request()) -> [proplist()].
 request_spot_instances(Request) ->
     request_spot_instances(Request, default_config()).
 
--spec(request_spot_instances/2 :: (ec2_spot_instance_request(), aws_config()) -> [proplist()]).
+-spec request_spot_instances(ec2_spot_instance_request(), aws_config()) -> [proplist()].
 request_spot_instances(Request, Config) ->
     InstanceSpec = Request#ec2_spot_instance_request.launch_specification,
     Params = [
@@ -1261,55 +1261,55 @@ request_spot_instances(Request, Config) ->
     [extract_spot_instance_request(Item) ||
      Item <- xmerl_xpath:string("/RequestSpotInstancesResponse/spotInstanceRequestSet/item", Doc)].
 
--spec(release_address/2 :: (string(), aws_config()) -> ok).
+-spec release_address(string(), aws_config()) -> ok.
 release_address(PublicIP, Config)
   when is_list(PublicIP) ->
     ec2_simple_query(Config, "ReleaseAddress", [{"PublicIp", PublicIP}]).
 
--spec(reset_image_attribute/2 :: (string(), atom()) -> ok).
+-spec reset_image_attribute(string(), atom()) -> ok.
 reset_image_attribute(ImageID, Attribute) ->
     reset_image_attribute(ImageID, Attribute, default_config()).
 
--spec(reset_image_attribute/3 :: (string(), atom(), aws_config()) -> ok).
+-spec reset_image_attribute(string(), atom(), aws_config()) -> ok.
 reset_image_attribute(ImageID, launch_permission, Config) ->
     ec2_simple_query(Config, "ResetImageAttribute",
         [{"ImageId", ImageID}, {"Attribute", "launchPermission"}]).
 
--spec(reset_instance_attribute/2 :: (string(), atom()) -> ok).
+-spec reset_instance_attribute(string(), atom()) -> ok.
 reset_instance_attribute(InstanceID, Attribute) ->
     reset_instance_attribute(InstanceID, Attribute, default_config()).
 
--spec(reset_instance_attribute/3 :: (string(), atom(), aws_config()) -> ok).
+-spec reset_instance_attribute(string(), atom(), aws_config()) -> ok.
 reset_instance_attribute(InstanceID, Attribute, Config)
   when is_list(InstanceID),
        Attribute =:= kernel orelse Attribute =:= ramdisk ->
     ec2_simple_query(Config, "ResetInstanceAttribute",
         [{"InstanceId", InstanceID}, {"Attribute", Attribute}]).
 
--spec(reset_snapshot_attribute/2 :: (string(), atom()) -> ok).
+-spec reset_snapshot_attribute(string(), atom()) -> ok.
 reset_snapshot_attribute(SnapshotID, Attribute) ->
     reset_snapshot_attribute(SnapshotID, Attribute, default_config()).
 
--spec(reset_snapshot_attribute/3 :: (string(), atom(), aws_config()) -> ok).
+-spec reset_snapshot_attribute(string(), atom(), aws_config()) -> ok.
 reset_snapshot_attribute(SnapshotID, create_volume_permission, Config)
   when is_list(SnapshotID) ->
     ec2_simple_query(Config, "ResetSnapshotAttribute",
         [{"snapshotId", SnapshotID}, {"Attribute", "createVolumePermission"}]).
 
--spec(revoke_security_group_ingress/2 :: (string(), ec2_ingress_spec()) -> ok).
+-spec revoke_security_group_ingress(string(), ec2_ingress_spec()) -> ok.
 revoke_security_group_ingress(GroupName, IngressSpec) ->
     revoke_security_group_ingress(GroupName, IngressSpec, default_config()).
 
--spec(revoke_security_group_ingress/3 :: (string(), ec2_ingress_spec(), aws_config()) -> ok).
+-spec revoke_security_group_ingress(string(), ec2_ingress_spec(), aws_config()) -> ok.
 revoke_security_group_ingress(GroupName, IngressSpec, Config)
   when is_list(GroupName), is_record(IngressSpec, ec2_ingress_spec) ->
     Params = [{"GroupName", GroupName}|ingress_spec_params(IngressSpec)],
     ec2_simple_query(Config, "RevokeSecurityGroupIngress", Params).
 
--spec(run_instances/1 :: (ec2_instance_spec()) -> proplist()).
+-spec run_instances(ec2_instance_spec()) -> proplist().
 run_instances(InstanceSpec) -> run_instances(InstanceSpec, default_config()).
 
--spec(run_instances/2 :: (ec2_instance_spec(), aws_config()) -> proplist()).
+-spec run_instances(ec2_instance_spec(), aws_config()) -> proplist().
 run_instances(InstanceSpec, Config)
   when is_record(InstanceSpec, ec2_instance_spec) ->
     Params = [
@@ -1367,36 +1367,36 @@ block_device_params(Mappings) ->
          end ||
          Mapping <- Mappings], "BlockDeviceMapping").
 
--spec(start_instances/1 :: ([string()]) -> proplist()).
+-spec start_instances([string()]) -> proplist().
 start_instances(InstanceIDs) -> start_instances(InstanceIDs, default_config()).
 
--spec(start_instances/2 :: ([string()], aws_config()) -> proplist()).
+-spec start_instances([string()], aws_config()) -> proplist().
 start_instances(InstanceIDs, Config)
   when is_list(InstanceIDs) ->
     Doc = ec2_query(Config, "StartInstances", erlcloud_aws:param_list(InstanceIDs, "InstanceId")),
     [extract_instance_state_change(Node) || Node <- xmerl_xpath:string("/StartInstancesResponse/instancesSet/item", Doc)].
 
--spec(stop_instances/1 :: ([string()]) -> proplist()).
+-spec stop_instances([string()]) -> proplist().
 stop_instances(InstanceIDs) -> stop_instances(InstanceIDs, default_config()).
 
--spec(stop_instances/2 :: ([string()], boolean() | aws_config()) -> proplist()).
+-spec stop_instances([string()], boolean() | aws_config()) -> proplist().
 stop_instances(InstanceIDs, Config)
   when is_record(Config, aws_config) ->
     stop_instances(InstanceIDs, false, Config);
 stop_instances(InstanceIDs, Force) ->
     stop_instances(InstanceIDs, Force, default_config()).
 
--spec(stop_instances/3 :: ([string()], boolean(), aws_config()) -> proplist()).
+-spec stop_instances([string()], boolean(), aws_config()) -> proplist().
 stop_instances(InstanceIDs, Force, Config)
   when is_list(InstanceIDs), is_boolean(Force) ->
     Doc = ec2_query(Config, "StopInstances",
       [{"Force", atom_to_list(Force)}|erlcloud_aws:param_list(InstanceIDs, "InstanceId")]),
     [extract_instance_state_change(Node) || Node <- xmerl_xpath:string("/StopInstancesResponse/instancesSet/item", Doc)].
 
--spec(terminate_instances/1 :: ([string()]) -> proplist()).
+-spec terminate_instances([string()]) -> proplist().
 terminate_instances(InstanceIDs) -> terminate_instances(InstanceIDs, default_config()).
 
--spec(terminate_instances/2 :: ([string()], aws_config()) -> proplist()).
+-spec terminate_instances([string()], aws_config()) -> proplist().
 terminate_instances(InstanceIDs, Config)
   when is_list(InstanceIDs) ->
     Doc = ec2_query(Config, "TerminateInstances", erlcloud_aws:param_list(InstanceIDs, "InstanceId")),
@@ -1415,11 +1415,11 @@ extract_instance_state_change(Node) ->
         }
     ].
 
--spec(unmonitor_instances/1 :: ([string()]) -> proplist()).
+-spec unmonitor_instances([string()]) -> proplist().
 unmonitor_instances(InstanceIDs) ->
     unmonitor_instances(InstanceIDs, default_config()).
 
--spec(unmonitor_instances/2 :: ([string()], aws_config()) -> [proplist()]).
+-spec unmonitor_instances([string()], aws_config()) -> [proplist()].
 unmonitor_instances(InstanceIDs, Config) ->
     Doc = ec2_query(Config, "UnmonitorInstances", erlcloud_aws:param_list(InstanceIDs, "InstanceId")),
     [extract_monitor_state(Node) || Node <- xmerl_xpath:string("/UnmonitorInstancesResponse/instancesSet/item", Doc)].

--- a/src/erlcloud_elb.erl
+++ b/src/erlcloud_elb.erl
@@ -22,23 +22,23 @@
 
 -import(erlcloud_xml, [get_text/2]).
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 elb_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.
@@ -79,11 +79,11 @@ delete_load_balancer(LB, Config) when is_list(LB) ->
                        [{"LoadBalancerName", LB}]).
 
 
--spec register_instance/2 :: (string(), string()) -> proplist().
+-spec register_instance(string(), string()) -> proplist().
 register_instance(LB, InstanceId) ->
     register_instance(LB, InstanceId, default_config()).
 
--spec register_instance/3 :: (string(), string(), aws_config()) -> proplist().
+-spec register_instance(string(), string(), aws_config()) -> proplist().
 register_instance(LB, InstanceId, Config) when is_list(LB) ->
     elb_simple_request(Config,
                        "RegisterInstancesWithLoadBalancer",
@@ -91,11 +91,11 @@ register_instance(LB, InstanceId, Config) when is_list(LB) ->
                         erlcloud_aws:param_list([[{"InstanceId", InstanceId}]], "Instances.member")]).
 
 
--spec deregister_instance/2 :: (string(), string()) -> proplist().
+-spec deregister_instance(string(), string()) -> proplist().
 deregister_instance(LB, InstanceId) ->
     deregister_instance(LB, InstanceId, default_config()).
 
--spec deregister_instance/3 :: (string(), string(), aws_config()) -> proplist().
+-spec deregister_instance(string(), string(), aws_config()) -> proplist().
 deregister_instance(LB, InstanceId, Config) when is_list(LB) ->
     elb_simple_request(Config,
                        "DeregisterInstancesFromLoadBalancer",
@@ -104,12 +104,12 @@ deregister_instance(LB, InstanceId, Config) when is_list(LB) ->
 
 
 
--spec configure_health_check/2 :: (string(), string()) -> proplist().
+-spec configure_health_check(string(), string()) -> proplist().
 configure_health_check(LB, Target) when is_list(LB),
                                         is_list(Target) ->
     configure_health_check(LB, Target, default_config()).
 
--spec configure_health_check/3 :: (string(), string(), aws_config()) -> proplist().
+-spec configure_health_check(string(), string(), aws_config()) -> proplist().
 configure_health_check(LB, Target, Config) when is_list(LB) ->
     elb_simple_request(Config,
                        "ConfigureHealthCheck",

--- a/src/erlcloud_mturk.erl
+++ b/src/erlcloud_mturk.erl
@@ -69,45 +69,45 @@
 -define(XMLNS_EXTERNALQUESTION, "http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2006-07-14/ExternalQuestion.xsd").
 -define(XMLNS_ANSWERKEY, "http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2005-10-01/AnswerKey.xsd").
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyId, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyId,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyId, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyId,
                 secret_access_key=SecretAccessKey,
                 mturk_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyId, SecretAccessKey) ->
     put(aws_config, new(AccessKeyId, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyId, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyId, SecretAccessKey, Host)),
     ok.
 
 default_config() -> erlcloud_aws:default_config().
 
--spec approve_assignment/2 :: (string(), string() | none) -> ok.
+-spec approve_assignment(string(), string() | none) -> ok.
 approve_assignment(AssignmentId, RequesterFeedback) ->
     approve_assignment(AssignmentId, RequesterFeedback, default_config()).
 
--spec approve_assignment/3 :: (string(), string() | none, aws_config()) -> ok.
+-spec approve_assignment(string(), string() | none, aws_config()) -> ok.
 approve_assignment(AssignmentId, RequesterFeedback, Config)
   when is_list(AssignmentId),
        is_list(RequesterFeedback) orelse RequesterFeedback =:= none ->
     mturk_simple_request(Config, "ApproveAssignment",
         [{"AssignmentId", AssignmentId}, {"RequesterFeedback", RequesterFeedback}]).
 
--spec assign_qualification/2 :: (string(), string()) -> ok.
+-spec assign_qualification(string(), string()) -> ok.
 assign_qualification(QualificationTypeId, WorkerId) ->
     assign_qualification(QualificationTypeId, WorkerId, default_config()).
 
--spec assign_qualification/3 :: (string(), string(), integer() | aws_config()) -> ok.
+-spec assign_qualification(string(), string(), integer() | aws_config()) -> ok.
 assign_qualification(QualificationTypeId, WorkerId, Config)
   when is_record(Config, aws_config) ->
     assign_qualification(QualificationTypeId, WorkerId, 1, Config);
@@ -115,7 +115,7 @@ assign_qualification(QualificationTypeId, WorkerId, IntegerValue) ->
     assign_qualification(QualificationTypeId, WorkerId, IntegerValue, false).
 
 
--spec assign_qualification/4 :: (string(), string(), integer(), boolean() | aws_config()) -> ok.
+-spec assign_qualification(string(), string(), integer(), boolean() | aws_config()) -> ok.
 assign_qualification(QualificationTypeId, WorkerId, IntegerValue, Config)
   when is_record(Config, aws_config) ->
     assign_qualification(QualificationTypeId, WorkerId, IntegerValue, false, Config);
@@ -123,7 +123,7 @@ assign_qualification(QualificationTypeId, WorkerId, IntegerValue, SendNotificati
     assign_qualification(QualificationTypeId, WorkerId, IntegerValue,
         SendNotification, default_config()).
 
--spec assign_qualification/5 :: (string(), string(), integer(), boolean(), aws_config()) -> ok.
+-spec assign_qualification(string(), string(), integer(), boolean(), aws_config()) -> ok.
 assign_qualification(QualificationTypeId, WorkerId, IntegerValue, SendNotification,
                      Config)
   when is_list(QualificationTypeId), is_list(WorkerId),
@@ -134,33 +134,33 @@ assign_qualification(QualificationTypeId, WorkerId, IntegerValue, SendNotificati
          {"IntegerValue", IntegerValue},
          {"SendNotification", SendNotification}]).
 
--spec block_worker/2 :: (string(), string()) -> ok.
+-spec block_worker(string(), string()) -> ok.
 block_worker(WorkerId, Reason) -> block_worker(WorkerId, Reason, default_config()).
 
--spec block_worker/3 :: (string(), string(), aws_config()) -> ok.
+-spec block_worker(string(), string(), aws_config()) -> ok.
 block_worker(WorkerId, Reason, Config)
   when is_list(WorkerId), is_list(Reason) ->
     mturk_simple_request(Config, "BlockWorker",
         [{"WorkerId", WorkerId}, {"Reason", Reason}]).
 
--spec change_hit_type_of_hit/2 :: (string(), string()) -> ok.
+-spec change_hit_type_of_hit(string(), string()) -> ok.
 change_hit_type_of_hit(HITId, HITTypeId) ->
     change_hit_type_of_hit(HITId, HITTypeId, default_config()).
 
--spec change_hit_type_of_hit/3 :: (string(), string(), aws_config()) -> ok.
+-spec change_hit_type_of_hit(string(), string(), aws_config()) -> ok.
 change_hit_type_of_hit(HITId, HITTypeId, Config)
   when is_list(HITId), is_list(HITTypeId) ->
     mturk_simple_request(Config, "ChangeHITTypeOfHIT",
         [{"HITId", HITId}, {"HITTypeId", HITTypeId}]).
 
--spec create_hit/5 :: (string(), mturk_question(), 30..3153600,
+-spec create_hit(string(), mturk_question(), 30..3153600,
                           1..1000000000, string() | none) -> proplist().
 create_hit(HITTypeId, Question, LifetimeInSeconds, MaxAssignments,
            RequesterAnnotation) ->
     create_hit(HITTypeId, Question, LifetimeInSeconds, MaxAssignments,
         RequesterAnnotation, default_config()).
 
--spec create_hit/6 :: (string(), mturk_question(), 30..3153600,
+-spec create_hit(string(), mturk_question(), 30..3153600,
     1..1000000000, string() | none, aws_config()) -> proplist().
 create_hit(HITTypeId, Question, LifetimeInSeconds, MaxAssignments,
            RequesterAnnotation, Config)
@@ -187,11 +187,11 @@ create_hit(HITTypeId, Question, LifetimeInSeconds, MaxAssignments,
         Doc
     ).
 
--spec create_hit/1 :: (#mturk_hit{}) -> proplist().
+-spec create_hit(#mturk_hit{}) -> proplist().
 create_hit(HIT) ->
     create_hit(HIT, default_config()).
 
--spec create_hit/2 :: (#mturk_hit{}, aws_config()) -> proplist().
+-spec create_hit(#mturk_hit{}, aws_config()) -> proplist().
 create_hit(HIT, Config) ->
     QuestionXML = xml_to_string(encode_xml(HIT#mturk_hit.question)),
     Params = [
@@ -245,11 +245,11 @@ encode_locale_value(undefined) -> [];
 encode_locale_value(#mturk_locale{country_code=Country}) ->
     [{"Country", Country}].
 
--spec create_qualification_type/1 :: (#mturk_qualification_type{}) -> proplist().
+-spec create_qualification_type(#mturk_qualification_type{}) -> proplist().
 create_qualification_type(QType) ->
     create_qualification_type(QType, default_config()).
 
--spec create_qualification_type/2 :: (#mturk_qualification_type{}, aws_config()) -> proplist().
+-spec create_qualification_type(#mturk_qualification_type{}, aws_config()) -> proplist().
 create_qualification_type(QType, Config)
   when is_record(QType, mturk_qualification_type) ->
     Doc = mturk_xml_request(Config, "CreateQualificationType",
@@ -274,38 +274,38 @@ qualification_type_params(QType) ->
         {"AutoGrantedValue", case AutoGranted of true -> AutoGrantedValue; false -> undefined end}
     ].
 
--spec disable_hit/1 :: (string()) -> ok.
+-spec disable_hit(string()) -> ok.
 disable_hit(HITId) -> disable_hit(HITId, default_config()).
 
--spec disable_hit/2 :: (string(), aws_config()) -> ok.
+-spec disable_hit(string(), aws_config()) -> ok.
 disable_hit(HITId, Config)
   when is_list(HITId) ->
     mturk_simple_request(Config, "DisableHIT", [{"HITId", HITId}]).
 
--spec dispose_hit/1 :: (string()) -> ok.
+-spec dispose_hit(string()) -> ok.
 dispose_hit(HITId) -> dispose_hit(HITId, default_config()).
 
--spec dispose_hit/2 :: (string(), aws_config()) -> ok.
+-spec dispose_hit(string(), aws_config()) -> ok.
 dispose_hit(HITId, Config)
   when is_list(HITId) ->
     mturk_simple_request(Config, "DisposeHIT", [{"HITId", HITId}]).
 
--spec dispose_qualification_type/1 :: (string()) -> ok.
+-spec dispose_qualification_type(string()) -> ok.
 dispose_qualification_type(QualificationTypeId) ->
     dispose_qualification_type(QualificationTypeId, default_config()).
 
--spec dispose_qualification_type/2 :: (string(), aws_config()) -> ok.
+-spec dispose_qualification_type(string(), aws_config()) -> ok.
 dispose_qualification_type(QualificationTypeId, Config)
   when is_list(QualificationTypeId) ->
     mturk_simple_request(Config, "DisposeQualificationType",
         [{"QualificationTypeId", QualificationTypeId}]).
 
--spec extend_hit/3 :: (string(), 1..1000000000 | none, 3600..31536000 | none) -> ok.
+-spec extend_hit(string(), 1..1000000000 | none, 3600..31536000 | none) -> ok.
 extend_hit(HITId, MaxAssignmentsIncrement, ExpirationIncrementInSeconds) ->
     extend_hit(HITId, MaxAssignmentsIncrement, ExpirationIncrementInSeconds,
                default_config()).
 
--spec extend_hit/4 :: (string(), 1..1000000000 | none, 3600..31536000 | none, aws_config()) -> ok.
+-spec extend_hit(string(), 1..1000000000 | none, 3600..31536000 | none, aws_config()) -> ok.
 extend_hit(HITId, MaxAssignmentsIncrement, ExpirationIncrementInSeconds, Config)
   when is_list(HITId),
        (MaxAssignmentsIncrement >= 1 andalso MaxAssignmentsIncrement =< 1000000000) orelse MaxAssignmentsIncrement =:= none,
@@ -316,19 +316,19 @@ extend_hit(HITId, MaxAssignmentsIncrement, ExpirationIncrementInSeconds, Config)
          {"MaxAssignmentsIncrement", MaxAssignmentsIncrement},
          {"ExpirationIncrementInSeconds", ExpirationIncrementInSeconds}]).
 
--spec force_expire_hit/1 :: (string()) -> ok.
+-spec force_expire_hit(string()) -> ok.
 force_expire_hit(HITId) -> force_expire_hit(HITId, default_config()).
 
--spec force_expire_hit/2 :: (string(), aws_config()) -> ok.
+-spec force_expire_hit(string(), aws_config()) -> ok.
 force_expire_hit(HITId, Config)
   when is_list(HITId) ->
     mturk_simple_request(Config, "ForceExpireHIT", [{"HITId", HITId}]).
 
--spec get_account_balance/0 :: () -> proplist().
+-spec get_account_balance() -> proplist().
 get_account_balance() ->
     get_account_balance(default_config()).
 
--spec get_account_balance/1 :: (aws_config()) -> proplist().
+-spec get_account_balance(aws_config()) -> proplist().
 get_account_balance(Config) ->
     Doc = mturk_xml_request(Config, "GetAccountBalance", []),
     erlcloud_xml:decode(
@@ -339,18 +339,18 @@ get_account_balance(Config) ->
         Doc
     ).
 
--spec get_assignments_for_hit/1 :: (string()) -> proplist().
+-spec get_assignments_for_hit(string()) -> proplist().
 get_assignments_for_hit(HITId) ->
     get_assignments_for_hit(HITId, []).
 
--spec get_assignments_for_hit/2 :: (string(), proplist() | aws_config()) -> proplist().
+-spec get_assignments_for_hit(string(), proplist() | aws_config()) -> proplist().
 get_assignments_for_hit(HITId, Config)
   when is_record(Config, aws_config) ->
     get_assignments_for_hit(HITId, [], Config);
 get_assignments_for_hit(HITId, Options) ->
     get_assignments_for_hit(HITId, Options, default_config()).
 
--spec get_assignments_for_hit/3 :: (string(), proplist(), aws_config()) -> proplist().
+-spec get_assignments_for_hit(string(), proplist(), aws_config()) -> proplist().
 get_assignments_for_hit(HITId, Options, Config)
   when is_list(HITId), is_list(Options) ->
     Params = [
@@ -411,11 +411,11 @@ extract_assignment(Assignment) ->
         Assignment
     ).
 
--spec get_bonus_payments_for_hit/2 :: (string(), proplist()) -> proplist().
+-spec get_bonus_payments_for_hit(string(), proplist()) -> proplist().
 get_bonus_payments_for_hit(HITId, Options) ->
     get_bonus_payments_for_hit(HITId, Options, default_config()).
 
--spec get_bonus_payments_for_hit/3 :: (string(), proplist(), aws_config()) -> proplist().
+-spec get_bonus_payments_for_hit(string(), proplist(), aws_config()) -> proplist().
 get_bonus_payments_for_hit(HITId, Options, Config)
   when is_list(HITId), is_list(Options) ->
       Params = [
@@ -426,11 +426,11 @@ get_bonus_payments_for_hit(HITId, Options, Config)
       Doc = mturk_xml_request(Config, "GetBonusPayments", Params),
       extract_bonus_payments(Doc).
 
--spec get_bonus_payments_for_assignment/2 :: (string(), proplist()) -> proplist().
+-spec get_bonus_payments_for_assignment(string(), proplist()) -> proplist().
 get_bonus_payments_for_assignment(AssignmentId, Options) ->
     get_bonus_payments_for_assignment(AssignmentId, Options, default_config()).
 
--spec get_bonus_payments_for_assignment/3 :: (string(), proplist(), aws_config()) -> proplist().
+-spec get_bonus_payments_for_assignment(string(), proplist(), aws_config()) -> proplist().
 get_bonus_payments_for_assignment(AssignmentId, Options, Config)
   when is_list(AssignmentId), is_list(Options) ->
       Params = [
@@ -466,11 +466,11 @@ extract_bonus_payment(Payment) ->
         Payment
     ).
 
--spec get_file_upload_url/2 :: (string(), string()) -> string().
+-spec get_file_upload_url(string(), string()) -> string().
 get_file_upload_url(AssignmentId, QuestionIdentifier) ->
     get_file_upload_url(AssignmentId, QuestionIdentifier, default_config()).
 
--spec get_file_upload_url/3 :: (string(), string(), aws_config()) -> string().
+-spec get_file_upload_url(string(), string(), aws_config()) -> string().
 get_file_upload_url(AssignmentId, QuestionIdentifier, Config)
   when is_record(Config, aws_config) ->
     Params = [
@@ -480,27 +480,27 @@ get_file_upload_url(AssignmentId, QuestionIdentifier, Config)
     Doc = mturk_xml_request(Config, "GetFileUploadURL", Params),
     erlcloud_xml:get_text("FileUploadURL", Doc).
 
--spec get_hit/1 :: (string()) -> #mturk_hit{}.
+-spec get_hit(string()) -> #mturk_hit{}.
 get_hit(HITId) -> get_hit(HITId, default_config()).
 
--spec get_hit/2 :: (string(), aws_config()) -> #mturk_hit{}.
+-spec get_hit(string(), aws_config()) -> #mturk_hit{}.
 get_hit(HITId, Config)
   when is_list(HITId) ->
     Doc = mturk_xml_request(Config, "GetHIT", [{"HITId", HITId}]),
     hd(extract_hits([Doc])).
 
--spec get_hits_for_qualification_type/1 :: (string()) -> proplist().
+-spec get_hits_for_qualification_type(string()) -> proplist().
 get_hits_for_qualification_type(QualificationTypeId) ->
     get_hits_for_qualification_type(QualificationTypeId, []).
 
--spec get_hits_for_qualification_type/2 :: (string(), proplist() | aws_config()) -> proplist().
+-spec get_hits_for_qualification_type(string(), proplist() | aws_config()) -> proplist().
 get_hits_for_qualification_type(QualificationTypeId, Config)
   when is_record(Config, aws_config) ->
     get_hits_for_qualification_type(QualificationTypeId, [], Config);
 get_hits_for_qualification_type(QualificationTypeId, Options) ->
     get_hits_for_qualification_type(QualificationTypeId, Options, default_config()).
 
--spec get_hits_for_qualification_type/3 :: (string(), proplist(), aws_config()) -> proplist().
+-spec get_hits_for_qualification_type(string(), proplist(), aws_config()) -> proplist().
 get_hits_for_qualification_type(QualificationTypeId, Options, Config)
   when is_list(Options) ->
     Params = [
@@ -519,18 +519,18 @@ get_hits_for_qualification_type(QualificationTypeId, Options, Config)
         Doc
     ).
 
--spec get_reviewable_hits/0 :: () -> proplist().
+-spec get_reviewable_hits() -> proplist().
 get_reviewable_hits() ->
     get_reviewable_hits([]).
 
--spec get_reviewable_hits/1 :: (proplist() | aws_config()) -> proplist().
+-spec get_reviewable_hits(proplist() | aws_config()) -> proplist().
 get_reviewable_hits(Config)
   when is_record(Config, aws_config) ->
     get_reviewable_hits([], Config);
 get_reviewable_hits(Options) ->
     get_reviewable_hits(Options, default_config()).
 
--spec get_reviewable_hits/2 :: (proplist(), aws_config()) -> proplist().
+-spec get_reviewable_hits(proplist(), aws_config()) -> proplist().
 get_reviewable_hits(Options, Config)
   when is_list(Options) ->
     Params = [
@@ -573,11 +573,11 @@ get_reviewable_hits(Options, Config)
         Doc
     ).
 
--spec get_qualification_score/2 :: (string(), string()) -> proplist().
+-spec get_qualification_score(string(), string()) -> proplist().
 get_qualification_score(QualificationTypeId, SubjectId) ->
     get_qualification_score(QualificationTypeId, SubjectId, default_config()).
 
--spec get_qualification_score/3 :: (string(), string(), aws_config()) -> proplist().
+-spec get_qualification_score(string(), string(), aws_config()) -> proplist().
 get_qualification_score(QualificationTypeId, SubjectId, Config)
   when is_list(QualificationTypeId), is_list(SubjectId) ->
     Doc = mturk_xml_request(Config, "GetQualificationScore",
@@ -596,11 +596,11 @@ get_qualification_score(QualificationTypeId, SubjectId, Config)
         Doc
     ).
 
--spec get_qualification_type/1 :: (string()) -> #mturk_qualification_type{}.
+-spec get_qualification_type(string()) -> #mturk_qualification_type{}.
 get_qualification_type(QualificationTypeId) ->
     get_qualification_type(QualificationTypeId, default_config()).
 
--spec get_qualification_type/2 :: (string(), aws_config()) -> #mturk_qualification_type{}.
+-spec get_qualification_type(string(), aws_config()) -> #mturk_qualification_type{}.
 get_qualification_type(QualificationTypeId, Config)
   when is_record(Config, aws_config) ->
     Doc = mturk_xml_request(Config, "GetQualificationType",
@@ -635,18 +635,18 @@ extract_qualification_type(Node) ->
 decode_keywords(String) ->
     [string:strip(Keyword) || Keyword <- string:tokens(String, ",")].
 
--spec get_qualifications_for_qualification_type/1 :: (string()) -> proplist().
+-spec get_qualifications_for_qualification_type(string()) -> proplist().
 get_qualifications_for_qualification_type(QualificationTypeId) ->
     get_qualifications_for_qualification_type(QualificationTypeId, default_config()).
 
--spec get_qualifications_for_qualification_type/2 :: (string(), proplist() | aws_config()) -> proplist().
+-spec get_qualifications_for_qualification_type(string(), proplist() | aws_config()) -> proplist().
 get_qualifications_for_qualification_type(QualificationTypeId, Config)
   when is_record(Config, aws_config) ->
     get_qualifications_for_qualification_type(QualificationTypeId, [], Config);
 get_qualifications_for_qualification_type(QualificationTypeId, Options) ->
     get_qualifications_for_qualification_type(QualificationTypeId, Options, default_config()).
 
--spec get_qualifications_for_qualification_type/3 :: (string(), proplist(), aws_config()) -> proplist().
+-spec get_qualifications_for_qualification_type(string(), proplist(), aws_config()) -> proplist().
 get_qualifications_for_qualification_type(QualificationTypeId, Options, Config)
   when is_list(QualificationTypeId), is_list(Options) ->
     Params = [
@@ -672,18 +672,18 @@ get_qualifications_for_qualification_type(QualificationTypeId, Options, Config)
         Item
     ) || Item <- xmerl_xpath:string("Qualification", Doc)].
 
--spec get_qualification_requests/0 :: () -> proplist().
+-spec get_qualification_requests() -> proplist().
 get_qualification_requests() ->
     get_qualification_requests([]).
 
--spec get_qualification_requests/1 :: (proplist() | aws_config()) -> proplist().
+-spec get_qualification_requests(proplist() | aws_config()) -> proplist().
 get_qualification_requests(Config)
   when is_record(Config, aws_config) ->
     get_qualification_requests([], Config);
 get_qualification_requests(Options) ->
     get_qualification_requests(Options, default_config()).
 
--spec get_qualification_requests/2 :: (proplist(), aws_config()) -> proplist().
+-spec get_qualification_requests(proplist(), aws_config()) -> proplist().
 get_qualification_requests(Options, Config)
   when is_list(Options) ->
     Params = [
@@ -732,18 +732,18 @@ extract_qualification_request(Request) ->
         Request
     ).
 
--spec get_requester_statistic/2 :: (string(), one_day | seven_days | thirty_days | life_to_date) -> [{datetime(), float()}].
+-spec get_requester_statistic(string(), one_day | seven_days | thirty_days | life_to_date) -> [{datetime(), float()}].
 get_requester_statistic(Statistic, TimePeriod) ->
     get_requester_statistic(Statistic, TimePeriod, default_config()).
 
--spec get_requester_statistic/3 :: (string(), one_day | seven_days | thirty_days | life_to_date, pos_integer() | aws_config()) -> [{datetime(), float()}].
+-spec get_requester_statistic(string(), one_day | seven_days | thirty_days | life_to_date, pos_integer() | aws_config()) -> [{datetime(), float()}].
 get_requester_statistic(Statistic, TimePeriod, Config)
   when is_record(Config, aws_config) ->
     get_requester_statistic(Statistic, TimePeriod, 1, Config);
 get_requester_statistic(Statistic, TimePeriod, Count) ->
     get_requester_statistic(Statistic, TimePeriod, Count, default_config()).
 
--spec get_requester_statistic/4 :: (string(), one_day | seven_days | thirty_days | life_to_date, pos_integer(), aws_config()) -> [{datetime(), float()}].
+-spec get_requester_statistic(string(), one_day | seven_days | thirty_days | life_to_date, pos_integer(), aws_config()) -> [{datetime(), float()}].
 get_requester_statistic(Statistic, TimePeriod, Count, Config)
   when is_list(Statistic),
        TimePeriod =:= one_day orelse TimePeriod =:= seven_days orelse
@@ -769,11 +769,11 @@ get_requester_statistic(Statistic, TimePeriod, Count, Config)
       end} ||
      DP <- xmerl_xpath:string("DataPoint", Doc)].
 
--spec grant_bonus/4 :: (string(), string(), #mturk_money{}, string()) -> ok.
+-spec grant_bonus(string(), string(), #mturk_money{}, string()) -> ok.
 grant_bonus(WorkerId, AssignmentId, BonusAmount, Reason) ->
     grant_bonus(WorkerId, AssignmentId, BonusAmount, Reason, default_config()).
 
--spec grant_bonus/5 :: (string(), string(), #mturk_money{}, string(), aws_config()) -> ok.
+-spec grant_bonus(string(), string(), #mturk_money{}, string(), aws_config()) -> ok.
 grant_bonus(WorkerId, AssignmentId, BonusAmount, Reason, Config) ->
     mturk_simple_request(Config, "GrantBonus",
         [
@@ -784,18 +784,18 @@ grant_bonus(WorkerId, AssignmentId, BonusAmount, Reason, Config) ->
         ]
     ).
 
--spec grant_qualification/1 :: (string()) -> ok.
+-spec grant_qualification(string()) -> ok.
 grant_qualification(QualificationRequestId) ->
     grant_qualification(QualificationRequestId, none).
 
--spec grant_qualification/2 :: (string(), integer() | none | aws_config()) -> ok.
+-spec grant_qualification(string(), integer() | none | aws_config()) -> ok.
 grant_qualification(QualificationRequestId, Config)
   when is_record(Config, aws_config) ->
     grant_qualification(QualificationRequestId, none, Config);
 grant_qualification(QualificationRequestId, Value) ->
     grant_qualification(QualificationRequestId, Value, default_config()).
 
--spec grant_qualification/3 :: (string(), integer() | none, aws_config()) -> ok.
+-spec grant_qualification(string(), integer() | none, aws_config()) -> ok.
 grant_qualification(QualificationRequestId, Value, Config)
   when is_list(QualificationRequestId),
        is_integer(Value) orelse Value =:= none ->
@@ -1090,11 +1090,11 @@ extract_money(Money) ->
 encode_money(#mturk_money{amount=Amount, currency_code=CurrencyCode}) ->
     [{"Amount", Amount}, {"CurrencyCode", CurrencyCode}].
 
--spec notify_workers/3 :: (string(), string(), [string()]) -> ok.
+-spec notify_workers(string(), string(), [string()]) -> ok.
 notify_workers(Subject, MessageText, WorkerIds) ->
     notify_workers(Subject, MessageText, WorkerIds, default_config()).
 
--spec notify_workers/4 :: (string(), string(), [string()], aws_config()) -> ok.
+-spec notify_workers(string(), string(), [string()], aws_config()) -> ok.
 notify_workers(Subject, MessageText, WorkerIds, Config)
   when is_list(Subject), is_list(MessageText),
        is_list(WorkerIds), length(WorkerIds) =< 100 ->
@@ -1106,11 +1106,11 @@ notify_workers(Subject, MessageText, WorkerIds, Config)
         ]
     ).
 
--spec register_hit_type/1 :: (#mturk_hit{}) -> proplist().
+-spec register_hit_type(#mturk_hit{}) -> proplist().
 register_hit_type(HIT) ->
     register_hit_type(HIT, default_config()).
 
--spec register_hit_type/2 :: (#mturk_hit{}, aws_config()) -> proplist().
+-spec register_hit_type(#mturk_hit{}, aws_config()) -> proplist().
 register_hit_type(HIT, Config) ->
     Params = [
         {"Title", HIT#mturk_hit.title},
@@ -1130,18 +1130,18 @@ register_hit_type(HIT, Config) ->
         Doc
     ).
 
--spec reject_assignment/1 :: (string()) -> ok.
+-spec reject_assignment(string()) -> ok.
 reject_assignment(AssignmentId) ->
     reject_assignment(AssignmentId, none).
 
--spec reject_assignment/2 :: (string(), string() | none | aws_config()) -> ok.
+-spec reject_assignment(string(), string() | none | aws_config()) -> ok.
 reject_assignment(AssignmentId, Config)
   when is_record(Config, aws_config) ->
     reject_assignment(AssignmentId, none, Config);
 reject_assignment(AssignmentId, Reason) ->
     reject_assignment(AssignmentId, Reason, default_config()).
 
--spec reject_assignment/3 :: (string(), string() | none, aws_config()) -> ok.
+-spec reject_assignment(string(), string() | none, aws_config()) -> ok.
 reject_assignment(AssignmentId, Reason, Config)
   when is_list(AssignmentId),
        is_list(Reason) orelse Reason =:= none ->
@@ -1152,18 +1152,18 @@ reject_assignment(AssignmentId, Reason, Config)
         ]
     ).
 
--spec reject_qualification_request/1 :: (string()) -> ok.
+-spec reject_qualification_request(string()) -> ok.
 reject_qualification_request(QualificationRequestId) ->
     reject_qualification_request(QualificationRequestId, none).
 
--spec reject_qualification_request/2 :: (string(), string() | none | aws_config()) -> ok.
+-spec reject_qualification_request(string(), string() | none | aws_config()) -> ok.
 reject_qualification_request(QualificationRequestId, Config)
   when is_record(Config, aws_config) ->
     reject_qualification_request(QualificationRequestId, none, Config);
 reject_qualification_request(QualificationRequestId, Reason) ->
     reject_qualification_request(QualificationRequestId, Reason, default_config()).
 
--spec reject_qualification_request/3 :: (string(), string() | none, aws_config()) -> ok.
+-spec reject_qualification_request(string(), string() | none, aws_config()) -> ok.
 reject_qualification_request(QualificationRequestId, Reason, Config)
   when is_list(QualificationRequestId),
        is_list(Reason) orelse Reason =:= none ->
@@ -1174,18 +1174,18 @@ reject_qualification_request(QualificationRequestId, Reason, Config)
         ]
     ).
 
--spec revoke_qualification/2 :: (string(), string()) -> ok.
+-spec revoke_qualification(string(), string()) -> ok.
 revoke_qualification(QualificationTypeId, WorkerId) ->
     revoke_qualification(QualificationTypeId, WorkerId, none).
 
--spec revoke_qualification/3 :: (string(), string(), string() | none | aws_config()) -> ok.
+-spec revoke_qualification(string(), string(), string() | none | aws_config()) -> ok.
 revoke_qualification(QualificationTypeId, WorkerId, Config)
   when is_record(Config, aws_config) ->
     revoke_qualification(QualificationTypeId, WorkerId, none, Config);
 revoke_qualification(QualificationTypeId, WorkerId, Reason) ->
     revoke_qualification(QualificationTypeId, WorkerId, Reason, default_config()).
 
--spec revoke_qualification/4 :: (string(), string(), string() | none, aws_config()) -> ok.
+-spec revoke_qualification(string(), string(), string() | none, aws_config()) -> ok.
 revoke_qualification(QualificationTypeId, WorkerId, Reason, Config) ->
     mturk_simple_request(Config, "RevokeQualification",
         [
@@ -1195,18 +1195,18 @@ revoke_qualification(QualificationTypeId, WorkerId, Reason, Config) ->
         ]
     ).
 
--spec search_hits/0 :: () -> proplist().
+-spec search_hits() -> proplist().
 search_hits() ->
     search_hits([]).
 
--spec search_hits/1 :: (proplist() | aws_config()) -> proplist().
+-spec search_hits(proplist() | aws_config()) -> proplist().
 search_hits(Config)
   when is_record(Config, aws_config) ->
     search_hits([], Config);
 search_hits(Options) ->
     search_hits(Options, default_config()).
 
--spec search_hits/2 :: (proplist(), aws_config()) -> proplist().
+-spec search_hits(proplist(), aws_config()) -> proplist().
 search_hits(Options, Config)
   when is_list(Options) ->
     Params = [
@@ -1241,18 +1241,18 @@ search_hits(Options, Config)
         Doc
     ).
 
--spec search_qualification_types/0 :: () -> proplist().
+-spec search_qualification_types() -> proplist().
 search_qualification_types() ->
     search_qualification_types([]).
 
--spec search_qualification_types/1 :: (proplist() | aws_config()) -> proplist().
+-spec search_qualification_types(proplist() | aws_config()) -> proplist().
 search_qualification_types(Config)
   when is_record(Config, aws_config) ->
     search_qualification_types([], Config);
 search_qualification_types(Options) ->
     search_qualification_types(Options, default_config()).
 
--spec search_qualification_types/2 :: (proplist(), aws_config()) -> proplist().
+-spec search_qualification_types(proplist(), aws_config()) -> proplist().
 search_qualification_types(Options, Config) ->
     Params = [
         {"Query", proplists:get_value(search_query, Options)},
@@ -1285,11 +1285,11 @@ search_qualification_types(Options, Config) ->
         Doc
     ).
 
--spec send_test_event_notification/2 :: (proplist(), mturk_event_type()) -> ok.
+-spec send_test_event_notification(proplist(), mturk_event_type()) -> ok.
 send_test_event_notification(Notificaiton, TestEventType) ->
     send_test_event_notification(Notificaiton, TestEventType, default_config()).
 
--spec send_test_event_notification/3 :: (proplist(), mturk_event_type(), aws_config()) -> ok.
+-spec send_test_event_notification(proplist(), mturk_event_type(), aws_config()) -> ok.
 send_test_event_notification(Notification, TestEventType, Config) ->
     mturk_simple_request(Config, "SendTestEventNotification",
         [
@@ -1301,18 +1301,18 @@ send_test_event_notification(Notification, TestEventType, Config) ->
         ]
     ).
 
--spec set_hit_as_reviewing/1 :: (string()) -> ok.
+-spec set_hit_as_reviewing(string()) -> ok.
 set_hit_as_reviewing(HITId) ->
     set_hit_as_reviewing(HITId, false).
 
--spec set_hit_as_reviewing/2 :: (string(), boolean() | aws_config()) -> ok.
+-spec set_hit_as_reviewing(string(), boolean() | aws_config()) -> ok.
 set_hit_as_reviewing(HITId, Config)
   when is_record(Config, aws_config) ->
     set_hit_as_reviewing(HITId, false, Config);
 set_hit_as_reviewing(HITId, Revert) ->
     set_hit_as_reviewing(HITId, Revert, default_config()).
 
--spec set_hit_as_reviewing/3 :: (string(), boolean(), aws_config()) -> ok.
+-spec set_hit_as_reviewing(string(), boolean(), aws_config()) -> ok.
 set_hit_as_reviewing(HITId, Revert, Config) ->
     mturk_simple_request(Config, "SetHITAsReviewing",
         [
@@ -1321,18 +1321,18 @@ set_hit_as_reviewing(HITId, Revert, Config) ->
         ]
     ).
 
--spec set_hit_type_notification/2 :: (string(), proplist()) -> ok.
+-spec set_hit_type_notification(string(), proplist()) -> ok.
 set_hit_type_notification(HITTypeId, Notification) ->
     set_hit_type_notification(HITTypeId, Notification, undefined).
 
--spec set_hit_type_notification/3 :: (string(), proplist(), boolean() | undefined | aws_config()) -> ok.
+-spec set_hit_type_notification(string(), proplist(), boolean() | undefined | aws_config()) -> ok.
 set_hit_type_notification(HITTypeId, Notification, Config)
   when is_record(Config, aws_config) ->
     set_hit_type_notification(HITTypeId, Notification, undefined, Config);
 set_hit_type_notification(HITTypeId, Notification, Active) ->
     set_hit_type_notification(HITTypeId, Notification, Active, default_config()).
 
--spec set_hit_type_notification/4 :: (string(), proplist(), boolean() | undefined, aws_config()) -> ok.
+-spec set_hit_type_notification(string(), proplist(), boolean() | undefined, aws_config()) -> ok.
 set_hit_type_notification(HITTypeId, Notification, Active, Config)
   when is_list(HITTypeId), is_list(Notification),
        is_boolean(Active) orelse Active =:= undefined ->
@@ -1358,29 +1358,29 @@ encode_transport(email) -> "Email";
 encode_transport(soap) -> "SOAP";
 encode_transport(rest) -> "REST".
 
--spec unblock_worker/1 :: (string()) -> ok.
+-spec unblock_worker(string()) -> ok.
 unblock_worker(WorkerId) -> unblock_worker(WorkerId, none).
 
--spec unblock_worker/2 :: (string(), string() | none | aws_config()) -> ok.
+-spec unblock_worker(string(), string() | none | aws_config()) -> ok.
 unblock_worker(WorkerId, Config)
   when is_record(Config, aws_config) ->
     unblock_worker(WorkerId, none, Config);
 unblock_worker(WorkerId, Reason) ->
     unblock_worker(WorkerId, Reason, default_config()).
 
--spec unblock_worker/3 :: (string(), string() | none, aws_config()) -> ok.
+-spec unblock_worker(string(), string() | none, aws_config()) -> ok.
 unblock_worker(WorkerId, Reason, Config)
   when is_list(WorkerId),
        is_list(Reason) orelse Reason =:= none ->
     mturk_simple_request(Config, "UnblockWorker",
         [{"WorkerId", WorkerId}, {"Reason", Reason}]).
 
--spec update_qualification_score/3 :: (string(), string(), integer()) -> ok.
+-spec update_qualification_score(string(), string(), integer()) -> ok.
 update_qualification_score(QualificationTypeId, SubjectId, IntegerValue) ->
     update_qualification_score(QualificationTypeId, SubjectId, 
         IntegerValue, default_config()).
 
--spec update_qualification_score/4 :: (string(), string(), integer(), aws_config()) -> ok.
+-spec update_qualification_score(string(), string(), integer(), aws_config()) -> ok.
 update_qualification_score(QualificationTypeId, SubjectId, IntegerValue, Config)
   when is_list(SubjectId), is_list(QualificationTypeId),
        is_integer(IntegerValue) ->
@@ -1392,11 +1392,11 @@ update_qualification_score(QualificationTypeId, SubjectId, IntegerValue, Config)
         ]
     ).
 
--spec update_qualification_type/1 :: (#mturk_qualification_type{}) -> #mturk_qualification_type{}.
+-spec update_qualification_type(#mturk_qualification_type{}) -> #mturk_qualification_type{}.
 update_qualification_type(QType) ->
     update_qualification_type(QType, default_config()).
 
--spec update_qualification_type/2 :: (#mturk_qualification_type{}, aws_config()) -> #mturk_qualification_type{}.
+-spec update_qualification_type(#mturk_qualification_type{}, aws_config()) -> #mturk_qualification_type{}.
 update_qualification_type(QType, Config) ->
     Doc = mturk_xml_request(Config, "UpdateQualificationType",
         [
@@ -1599,7 +1599,7 @@ mturk_xml_request(Config, Operation, Params) ->
 mturk_request(Config, Operation, Params) ->
     Timestamp = erlcloud_aws:format_timestamp(erlang:universaltime()),
     StringToSign = [?API_SERVICE, Operation, Timestamp],
-    Signature = base64:encode(crypto:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
+    Signature = base64:encode(erlcloud_util:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
     
     QParams = [{"Operation", Operation}, {"Version", ?API_VERSION},
                {"Service", ?API_SERVICE}, {"Timestamp", Timestamp},

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -749,7 +749,7 @@ make_link(Expire_time, BucketName, Key, Config)
     Datetime = (Mega * 1000000) + Sec,
     Expires = integer_to_list(Expire_time + Datetime),
     To_sign = lists:flatten(["GET\n\n\n", Expires, "\n/", BucketName, "/", Key]),
-    Sig = base64:encode(crypto:sha_mac(Config#aws_config.secret_access_key, To_sign)),
+    Sig = base64:encode(erlcloud_util:sha_mac(Config#aws_config.secret_access_key, To_sign)),
     Host = lists:flatten(["http://", BucketName, ".", Config#aws_config.s3_host, port_spec(Config)]),
     URI = lists:flatten(["/", Key, "?AWSAccessKeyId=", erlcloud_http:url_encode(Config#aws_config.access_key_id), "&Signature=", erlcloud_http:url_encode(Sig), "&Expires=", Expires]),
     {list_to_integer(Expires),
@@ -930,7 +930,7 @@ make_authorization(Config, Method, ContentMD5, ContentType, Date, AmzHeaders,
                     format_subresources(Subresources)
 
                    ],
-    Signature = base64:encode(crypto:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
+    Signature = base64:encode(erlcloud_util:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
     ["AWS ", Config#aws_config.access_key_id, $:, Signature].
 
 format_subresources([]) ->

--- a/src/erlcloud_sdb.erl
+++ b/src/erlcloud_sdb.erl
@@ -32,52 +32,52 @@
 
 -define(API_VERSION, "2009-04-15").
 
--spec(new/2 :: (string(), string()) -> aws_config()).
+-spec new(string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey}.
 
--spec(new/3 :: (string(), string(), string()) -> aws_config()).
+-spec new(string(), string(), string()) -> aws_config().
 new(AccessKeyID, SecretAccessKey, Host) ->
     #aws_config{access_key_id=AccessKeyID,
                 secret_access_key=SecretAccessKey,
                 sdb_host=Host}.
 
--spec(configure/2 :: (string(), string()) -> ok).
+-spec configure(string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey)),
     ok.
 
--spec(configure/3 :: (string(), string(), string()) -> ok).
+-spec configure(string(), string(), string()) -> ok.
 configure(AccessKeyID, SecretAccessKey, Host) ->
     put(aws_config, new(AccessKeyID, SecretAccessKey, Host)),
     ok.
 
 default_config() -> erlcloud_aws:default_config().
 
--spec create_domain/1 :: (string()) -> proplist().
+-spec create_domain(string()) -> proplist().
 create_domain(Name) ->
     create_domain(Name, default_config()).
 
--spec create_domain/2 :: (string(), aws_config()) -> proplist().
+-spec create_domain(string(), aws_config()) -> proplist().
 create_domain(Name, Config)
   when is_list(Name) ->
     sdb_simple_request(Config, "CreateDomain", [{"DomainName", Name}]).
 
--spec delete_domain/1 :: (string()) -> proplist().
+-spec delete_domain(string()) -> proplist().
 delete_domain(Name) ->
     delete_domain(Name, default_config()).
 
--spec delete_domain/2 :: (string(), aws_config()) -> proplist().
+-spec delete_domain(string(), aws_config()) -> proplist().
 delete_domain(Name, Config)
   when is_list(Name) ->
     sdb_simple_request(Config, "DeleteDomain", [{"DomainName", Name}]).
 
--spec domain_metadata/1 :: (string()) -> proplist().
+-spec domain_metadata(string()) -> proplist().
 domain_metadata(Name) ->
     domain_metadata(Name, default_config()).
 
--spec domain_metadata/2 :: (string(), aws_config()) -> proplist().
+-spec domain_metadata(string(), aws_config()) -> proplist().
 domain_metadata(Name, Config)
   when is_list(Name) ->
     {Doc, Result} = sdb_request(Config, "DomainMetadata", [{"DomainName", Name}]),
@@ -93,36 +93,36 @@ domain_metadata(Name, Config)
     ], MR),
     [{domain_metadata, Metadata}|Result].
 
--spec batch_put_attributes/2 :: (string(), [{string(), sdb_attributes()}]) -> proplist().
+-spec batch_put_attributes(string(), [{string(), sdb_attributes()}]) -> proplist().
 batch_put_attributes(DomainName, Items) ->
     batch_put_attributes(DomainName, Items, default_config()).
 
--spec batch_put_attributes/3 :: (string(), [{string(), sdb_attributes()}], aws_config()) -> proplist().
+-spec batch_put_attributes(string(), [{string(), sdb_attributes()}], aws_config()) -> proplist().
 batch_put_attributes(DomainName, Items, Config)
   when is_list(DomainName), is_list(Items) ->
     ItemParams = [[{"ItemName", Name}|attributes_list(Attrs)] || {Name, Attrs} <- Items],
     sdb_simple_request(Config, "BatchPutAttributes",
         [{"DomainName", DomainName}|erlcloud_aws:param_list(ItemParams, "Item")]).
 
--spec delete_attributes/2 :: (string(), string()) -> proplist().
+-spec delete_attributes(string(), string()) -> proplist().
 delete_attributes(DomainName, ItemName) ->
     delete_attributes(DomainName, ItemName, []).
 
--spec delete_attributes/3 :: (string(), string(), sdb_delete_attributes() | aws_config()) -> proplist().
+-spec delete_attributes(string(), string(), sdb_delete_attributes() | aws_config()) -> proplist().
 delete_attributes(DomainName, ItemName, Config)
   when is_record(Config, aws_config) ->
     delete_attributes(DomainName, ItemName, [], Config);
 delete_attributes(DomainName, ItemName, Attributes) ->
     delete_attributes(DomainName, ItemName, Attributes, []).
 
--spec delete_attributes/4 :: (string(), string(), sdb_delete_attributes(), sdb_conditionals() | aws_config()) -> proplist().
+-spec delete_attributes(string(), string(), sdb_delete_attributes(), sdb_conditionals() | aws_config()) -> proplist().
 delete_attributes(DomainName, ItemName, Attributes, Config)
   when is_record(Config, aws_config) ->
     delete_attributes(DomainName, ItemName, Attributes, [], Config);
 delete_attributes(DomainName, ItemName, Attributes, Conditionals) ->
     delete_attributes(DomainName, ItemName, Attributes, Conditionals, default_config()).
 
--spec delete_attributes/5 :: (string(), string(), sdb_delete_attributes(), sdb_conditionals(), aws_config()) -> proplist().
+-spec delete_attributes(string(), string(), sdb_delete_attributes(), sdb_conditionals(), aws_config()) -> proplist().
 delete_attributes(DomainName, ItemName, Attributes, Conditionals, Config)
   when is_list(DomainName), is_list(ItemName), is_list(Attributes),
        is_list(Conditionals) ->
@@ -130,11 +130,11 @@ delete_attributes(DomainName, ItemName, Attributes, Conditionals, Config)
               delete_attributes_list(Attributes)] ++ conditionals_list(Conditionals),
     sdb_simple_request(Config, "DeleteAttributes", Params).
 
--spec get_attributes/2 :: (string(), string()) -> proplist().
+-spec get_attributes(string(), string()) -> proplist().
 get_attributes(DomainName, ItemName) ->
     get_attributes(DomainName, ItemName, []).
 
--spec get_attributes/3 :: (string(), string(), [string()] | boolean() | aws_config()) -> proplist().
+-spec get_attributes(string(), string(), [string()] | boolean() | aws_config()) -> proplist().
 get_attributes(DomainName, ItemName, Config)
   when is_record(Config, aws_config) ->
     get_attributes(DomainName, ItemName, [], Config);
@@ -144,7 +144,7 @@ get_attributes(DomainName, ItemName, ConsistentRead)
 get_attributes(DomainName, ItemName, AttributeNames) ->
     get_attributes(DomainName, ItemName, AttributeNames, false).
 
--spec get_attributes/4 :: (string(), string(), [string()], boolean() | aws_config()) -> proplist().
+-spec get_attributes(string(), string(), [string()], boolean() | aws_config()) -> proplist().
 get_attributes(DomainName, ItemName, AttributeNames, Config)
   when is_record(Config, aws_config) ->
     get_attributes(DomainName, ItemName, AttributeNames, false, Config);
@@ -152,7 +152,7 @@ get_attributes(DomainName, ItemName, AttributeNames, ConsistentRead) ->
     get_attributes(DomainName, ItemName, AttributeNames, ConsistentRead,
                    default_config()).
 
--spec get_attributes/5 :: (string(), string(), [string()], boolean(), aws_config()) -> proplist().
+-spec get_attributes(string(), string(), [string()], boolean(), aws_config()) -> proplist().
 get_attributes(DomainName, ItemName, AttributeNames, ConsistentRead, Config) ->
     {Doc, Result} = sdb_request(Config, "GetAttributes",
         [{"DomainName", DomainName}, {"ItemName", ItemName},
@@ -168,11 +168,11 @@ extract_attributes(Attributes) ->
 extract_attribute(Node) ->
     {erlcloud_xml:get_text("Name", Node), erlcloud_xml:get_text("Value", Node)}.
 
--spec list_domains/0 :: () -> proplist().
+-spec list_domains() -> proplist().
 list_domains() ->
     list_domains(default_config()).
 
--spec list_domains/1 :: (string() | 1..100 | none | aws_config()) -> proplist().
+-spec list_domains(string() | 1..100 | none | aws_config()) -> proplist().
 list_domains(Config) when is_record(Config, aws_config) ->
     list_domains("", Config);
 list_domains(MaxDomains) when is_integer(MaxDomains); MaxDomains =:= none ->
@@ -180,13 +180,13 @@ list_domains(MaxDomains) when is_integer(MaxDomains); MaxDomains =:= none ->
 list_domains(FirstToken) ->
     list_domains(FirstToken, none).
 
--spec list_domains/2 :: (string(), 1..100 | none | aws_config()) -> proplist().
+-spec list_domains(string(), 1..100 | none | aws_config()) -> proplist().
 list_domains(FirstToken, Config) when is_record(Config, aws_config) ->
     list_domains(FirstToken, none, Config);
 list_domains(FirstToken, MaxDomains) ->
     list_domains(FirstToken, MaxDomains, default_config()).
 
--spec list_domains/3 :: (string(), 1..100 | none, aws_config()) -> proplist().
+-spec list_domains(string(), 1..100 | none, aws_config()) -> proplist().
 list_domains(FirstToken, MaxDomains, Config)
   when is_list(FirstToken),
        is_integer(MaxDomains) orelse MaxDomains =:= none ->
@@ -194,18 +194,18 @@ list_domains(FirstToken, MaxDomains, Config)
         [{"MaxNumberOfDomains", MaxDomains}, {"FirstToken", FirstToken}]),
     [{domains, erlcloud_xml:get_list("/ListDomainsResponse/ListDomainsResult/DomainName", Doc)}|Result].
 
--spec put_attributes/3 :: (string(), string(), sdb_attributes()) -> proplist().
+-spec put_attributes(string(), string(), sdb_attributes()) -> proplist().
 put_attributes(DomainName, ItemName, Attributes) ->
     put_attributes(DomainName, ItemName, Attributes, []).
 
--spec put_attributes/4 :: (string(), string(), sdb_attributes(), sdb_conditionals() | aws_config()) -> proplist().
+-spec put_attributes(string(), string(), sdb_attributes(), sdb_conditionals() | aws_config()) -> proplist().
 put_attributes(DomainName, ItemName, Attributes, Config)
   when is_record(Config, aws_config) ->
     put_attributes(DomainName, ItemName, Attributes, [], Config);
 put_attributes(DomainName, ItemName, Attributes, Conditionals) ->
     put_attributes(DomainName, ItemName, Attributes, Conditionals, default_config()).
 
--spec put_attributes/5 :: (string(), string(), sdb_attributes(), sdb_conditionals(), aws_config()) -> proplist().
+-spec put_attributes(string(), string(), sdb_attributes(), sdb_conditionals(), aws_config()) -> proplist().
 put_attributes(DomainName, ItemName, Attributes, Conditionals, Config)
   when is_list(DomainName), is_list(ItemName), is_list(Attributes),
        is_list(Conditionals) ->
@@ -213,10 +213,10 @@ put_attributes(DomainName, ItemName, Attributes, Conditionals, Config)
               attributes_list(Attributes)] ++ conditionals_list(Conditionals),
     sdb_simple_request(Config, "PutAttributes", Params).
 
--spec select/1 :: (string()) -> proplist().
+-spec select(string()) -> proplist().
 select(SelectExpression) -> select(SelectExpression, none).
 
--spec select/2 :: (string(), string() | none | boolean() | aws_config()) -> proplist().
+-spec select(string(), string() | none | boolean() | aws_config()) -> proplist().
 select(SelectExpression, Config)
   when is_record(Config, aws_config) ->
     select(SelectExpression, none, Config);
@@ -226,14 +226,14 @@ select(SelectExpression, ConsistentRead)
 select(SelectExpression, NextToken) ->
     select(SelectExpression, NextToken, false).
 
--spec select/3 :: (string(), string() | none, boolean() | aws_config()) -> proplist().
+-spec select(string(), string() | none, boolean() | aws_config()) -> proplist().
 select(SelectExpression, NextToken, Config)
   when is_record(Config, aws_config) ->
     select(SelectExpression, NextToken, false, Config);
 select(SelectExpression, NextToken, ConsistentRead) ->
     select(SelectExpression, NextToken, ConsistentRead, default_config()).
 
--spec select/4 :: (string(), string() | none, boolean(), aws_config()) -> proplist().
+-spec select(string(), string() | none, boolean(), aws_config()) -> proplist().
 select(SelectExpression, NextToken, ConsistentRead, Config)
   when is_list(SelectExpression),
        is_list(NextToken) orelse NextToken =:= none,

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -32,11 +32,11 @@
     approximate_number_of_messages_not_visible | visibility_timeout |
     created_timestamp | last_modified_timestamp | policy).
 
--spec add_permission/3 :: (string(), string(), sqs_acl()) -> ok.
+-spec add_permission(string(), string(), sqs_acl()) -> ok.
 add_permission(QueueName, Label, Permissions) ->
     add_permission(QueueName, Label, Permissions, default_config()).
 
--spec add_permission/4 :: (string(), string(), sqs_acl(), aws_config()) -> ok.
+-spec add_permission(string(), string(), sqs_acl(), aws_config()) -> ok.
 add_permission(QueueName, Label, Permissions, Config)
   when is_list(QueueName),
        is_list(Label), length(Label) =< 80,
@@ -58,28 +58,28 @@ encode_permission({AccountId, Permission}) ->
          get_queue_attributes -> "GetQueueAttributes"
      end}.
 
--spec change_message_visibility/3 :: (string(), string(), 0..43200) -> ok.
+-spec change_message_visibility(string(), string(), 0..43200) -> ok.
 change_message_visibility(QueueName, ReceiptHandle, VisibilityTimeout) ->
     change_message_visibility(QueueName, ReceiptHandle, VisibilityTimeout,
         default_config()).
 
--spec change_message_visibility/4 :: (string(), string(), 0..43200, aws_config()) -> ok.
+-spec change_message_visibility(string(), string(), 0..43200, aws_config()) -> ok.
 change_message_visibility(QueueName, ReceiptHandle, VisibilityTimeout, Config) ->
     sqs_simple_request(Config, QueueName, "ChangeMessageVisibility",
         [{"ReceiptHandle", ReceiptHandle}, {"VisibilityTimeout", VisibilityTimeout}]).
 
--spec create_queue/1 :: (string()) -> proplist().
+-spec create_queue(string()) -> proplist().
 create_queue(QueueName) ->
     create_queue(QueueName, default_config()).
 
--spec create_queue/2 :: (string(), 0..43200 | none | aws_config()) -> proplist().
+-spec create_queue(string(), 0..43200 | none | aws_config()) -> proplist().
 create_queue(QueueName, Config)
   when is_record(Config, aws_config) ->
     create_queue(QueueName, none, Config);
 create_queue(QueueName, DefaultVisibilityTimeout) ->
     create_queue(QueueName, DefaultVisibilityTimeout, default_config()).
 
--spec create_queue/3 :: (string(), 0..43200 | none, aws_config()) -> proplist().
+-spec create_queue(string(), 0..43200 | none, aws_config()) -> proplist().
 create_queue(QueueName, DefaultVisibilityTimeout, Config)
   when is_list(QueueName),
        (is_integer(DefaultVisibilityTimeout) andalso
@@ -95,37 +95,37 @@ create_queue(QueueName, DefaultVisibilityTimeout, Config)
         Doc
     ).
 
--spec delete_message/2 :: (string(), string()) -> ok.
+-spec delete_message(string(), string()) -> ok.
 delete_message(QueueName, ReceiptHandle) ->
     delete_message(QueueName, ReceiptHandle, default_config()).
 
--spec delete_message/3 :: (string(), string(), aws_config()) -> ok.
+-spec delete_message(string(), string(), aws_config()) -> ok.
 delete_message(QueueName, ReceiptHandle, Config)
   when is_list(QueueName), is_list(ReceiptHandle) ->
     sqs_simple_request(Config, QueueName, "DeleteMessage",
         [{"ReceiptHandle", ReceiptHandle}]).
 
--spec delete_queue/1 :: (string()) -> ok.
+-spec delete_queue(string()) -> ok.
 delete_queue(QueueName) ->
     delete_queue(QueueName, default_config()).
 
--spec delete_queue/2 :: (string(), aws_config()) -> ok.
+-spec delete_queue(string(), aws_config()) -> ok.
 delete_queue(QueueName, Config)
   when is_list(QueueName) ->
     sqs_simple_request(Config, QueueName, "DeleteQueue", []).
 
--spec get_queue_attributes/1 :: (string()) -> proplist().
+-spec get_queue_attributes(string()) -> proplist().
 get_queue_attributes(QueueName) ->
     get_queue_attributes(QueueName, all).
 
--spec get_queue_attributes/2 :: (string(), all | [sqs_queue_attribute_name()] | aws_config()) -> proplist().
+-spec get_queue_attributes(string(), all | [sqs_queue_attribute_name()] | aws_config()) -> proplist().
 get_queue_attributes(QueueName, Config)
   when is_record(Config, aws_config) ->
     get_queue_attributes(QueueName, all, default_config());
 get_queue_attributes(QueueName, AttributeNames) ->
     get_queue_attributes(QueueName, AttributeNames, default_config()).
 
--spec get_queue_attributes/3 :: (string(), all | [sqs_queue_attribute_name()], aws_config()) -> proplist().
+-spec get_queue_attributes(string(), all | [sqs_queue_attribute_name()], aws_config()) -> proplist().
 get_queue_attributes(QueueName, all, Config) ->
     get_queue_attributes(QueueName, [all], Config);
 get_queue_attributes(QueueName, AttributeNames, Config)
@@ -159,43 +159,43 @@ decode_attribute_name("LastModifiedTimestamp") -> last_modified_timestamp;
 decode_attribute_name("CreatedTimestamp") -> created_timestamp;
 decode_attribute_name("Policy") -> policy.
 
--spec list_queues/0 :: () -> [string()].
+-spec list_queues() -> [string()].
 list_queues() ->
     list_queues("").
 
--spec list_queues/1 :: (string() | aws_config()) -> [string()].
+-spec list_queues(string() | aws_config()) -> [string()].
 list_queues(Config)
   when is_record(Config, aws_config) ->
     list_queues("", Config);
 list_queues(QueueNamePrefix) ->
     list_queues(QueueNamePrefix, default_config()).
 
--spec list_queues/2 :: (string(), aws_config()) -> [string()].
+-spec list_queues(string(), aws_config()) -> [string()].
 list_queues(QueueNamePrefix, Config)
   when is_list(QueueNamePrefix) ->
     Doc = sqs_xml_request(Config, "/", "ListQueues",
         [{"QueueNamePrefix", QueueNamePrefix}]),
     erlcloud_xml:get_list("ListQueuesResult/QueueUrl", Doc).
 
--spec receive_message/1 :: (string()) -> proplist().
+-spec receive_message(string()) -> proplist().
 receive_message(QueueName) ->
     receive_message(QueueName, default_config()).
 
--spec receive_message/2 :: (string(), [sqs_msg_attribute_name()] | all | aws_config()) -> proplist().
+-spec receive_message(string(), [sqs_msg_attribute_name()] | all | aws_config()) -> proplist().
 receive_message(QueueName, Config)
   when is_record(Config, aws_config) ->
     receive_message(QueueName, [], Config);
 receive_message(QueueName, AttributeNames) ->
     receive_message(QueueName, AttributeNames, default_config()).
 
--spec receive_message/3 :: (string(), [sqs_msg_attribute_name()] | all, 1..10 | aws_config()) -> proplist().
+-spec receive_message(string(), [sqs_msg_attribute_name()] | all, 1..10 | aws_config()) -> proplist().
 receive_message(QueueName, AttributeNames, Config)
   when is_record(Config, aws_config) ->
     receive_message(QueueName, AttributeNames, 1, Config);
 receive_message(QueueName, AttributeNames, MaxNumberOfMessages) ->
     receive_message(QueueName, AttributeNames, MaxNumberOfMessages, default_config()).
 
--spec receive_message/4 :: (string(), [sqs_msg_attribute_name()] | all, 1..10, 0..43200 | none | aws_config()) -> proplist().
+-spec receive_message(string(), [sqs_msg_attribute_name()] | all, 1..10, 0..43200 | none | aws_config()) -> proplist().
 receive_message(QueueName, AttributeNames, MaxNumberOfMessages, Config)
   when is_record(Config, aws_config) ->
     receive_message(QueueName, AttributeNames, MaxNumberOfMessages, none, Config);
@@ -203,7 +203,7 @@ receive_message(QueueName, AttributeNames, MaxNumberOfMessages, VisibilityTimeou
     receive_message(QueueName, AttributeNames, MaxNumberOfMessages,
                     VisibilityTimeout, default_config()).
 
--spec receive_message/5 :: (string(), [sqs_msg_attribute_name()] | all, 1..10,
+-spec receive_message(string(), [sqs_msg_attribute_name()] | all, 1..10,
                             0..43200 | none, aws_config()) -> proplist().
 receive_message(QueueName, all, MaxNumberOfMessages, VisibilityTimeout, Config) ->
     receive_message(QueueName, [all], MaxNumberOfMessages,
@@ -263,21 +263,21 @@ decode_attributes(Attrs) ->
     [{erlcloud_xml:get_text("Name", Attr), erlcloud_xml:get_text("Value", Attr)} ||
      Attr <- Attrs].
 
--spec remove_permission/2 :: (string(), string()) -> ok.
+-spec remove_permission(string(), string()) -> ok.
 remove_permission(QueueName, Label) ->
     remove_permission(QueueName, Label, default_config()).
 
--spec remove_permission/3 :: (string(), string(), aws_config()) -> ok.
+-spec remove_permission(string(), string(), aws_config()) -> ok.
 remove_permission(QueueName, Label, Config)
   when is_list(QueueName), is_list(Label) ->
     sqs_simple_request(Config, QueueName, "RemovePermission",
         [{"Label", Label}]).
 
--spec send_message/2 :: (string(), string()) -> proplist().
+-spec send_message(string(), string()) -> proplist().
 send_message(QueueName, MessageBody) ->
     send_message(QueueName, MessageBody, default_config()).
 
--spec send_message/3 :: (string(), string(), aws_config()) -> proplist().
+-spec send_message(string(), string(), aws_config()) -> proplist().
 send_message(QueueName, MessageBody, Config)
   when is_list(QueueName), is_list(MessageBody) ->
     Doc = sqs_xml_request(Config, QueueName, "SendMessage",
@@ -290,11 +290,11 @@ send_message(QueueName, MessageBody, Config)
         Doc
     ).
 
--spec set_queue_attributes/2 :: (string(), [{visibility_timeout, integer()} | {policy, string()}]) -> ok.
+-spec set_queue_attributes(string(), [{visibility_timeout, integer()} | {policy, string()}]) -> ok.
 set_queue_attributes(QueueName, Attributes) ->
     set_queue_attributes(QueueName, Attributes, default_config()).
 
--spec set_queue_attributes/3 :: (string(), [{visibility_timeout, integer()} | {policy, string()}], aws_config()) -> ok.
+-spec set_queue_attributes(string(), [{visibility_timeout, integer()} | {policy, string()}], aws_config()) -> ok.
 set_queue_attributes(QueueName, Attributes, Config)
   when is_list(QueueName), is_list(Attributes) ->
     Params = [[{"Name", encode_attribute_name(Name)}, {"Value", Value}] ||

--- a/src/erlcloud_util.erl
+++ b/src/erlcloud_util.erl
@@ -1,0 +1,5 @@
+-module(erlcloud_util).
+-export([sha_mac/2]).
+
+sha_mac(K, S) ->
+    crypto:hmac(sha, K, S).


### PR DESCRIPTION
- Upgraded ibrowse to 4.4.0 for R20 compatibility
- Changed -specs to function(args) format
- Added `erlcloud_util:sha_mac` to replace `crypto:sha_mac`

The changes followed the direction and code of erlcloud/erlcloud wherever possible. It might be possible to cherry-pick these changes instead, but this fork has diverged quite a lot over the years from the more active development on the upstream. It didn't seem worth the effort.

There are no tests in this fork, unlike the current upstream. I've manually tested many of the erlcloud_s3 functions (mainly gets, puts, creating and listing buckets), and by extension anything they rely on. I've made no attempt to test anything outside of that. I'm not sure what else was ever used with any Basho product though.